### PR TITLE
Frontend Customize Color

### DIFF
--- a/DaysSince.xcodeproj/project.pbxproj
+++ b/DaysSince.xcodeproj/project.pbxproj
@@ -29,7 +29,6 @@
 		7A7CD913287F2E760001C64F /* CreateFirstEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7CD912287F2E760001C64F /* CreateFirstEvent.swift */; };
 		7A868D182890814A009C92D6 /* DetailedTimeDisplayMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A868D172890814A009C92D6 /* DetailedTimeDisplayMode.swift */; };
 		7AAB507727FF86CC0086A5A8 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AAB507627FF86CC0086A5A8 /* Defaults.swift */; };
-		7AB3BC822ABF89F800549CD9 /* ThemeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB3BC812ABF89F800549CD9 /* ThemeButton.swift */; };
 		7AB3BC852ABF917C00549CD9 /* Defaults in Frameworks */ = {isa = PBXBuildFile; productRef = 7AB3BC842ABF917C00549CD9 /* Defaults */; };
 		7AB3BC872ABF91C000549CD9 /* Defaults+Extension+Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB3BC862ABF91C000549CD9 /* Defaults+Extension+Colors.swift */; };
 		7AB3BC892AC0CB2300549CD9 /* ThemeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB3BC882AC0CB2300549CD9 /* ThemeView.swift */; };
@@ -180,7 +179,6 @@
 		7A868D172890814A009C92D6 /* DetailedTimeDisplayMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailedTimeDisplayMode.swift; sourceTree = "<group>"; };
 		7AAB507327FF860C0086A5A8 /* Defaults */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Defaults; path = "../../../../../Library/Developer/Xcode/DerivedData/Posture_Pal-baxwxadtvwjgulhdvdslumckelkv/SourcePackages/checkouts/Defaults"; sourceTree = "<group>"; };
 		7AAB507627FF86CC0086A5A8 /* Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
-		7AB3BC812ABF89F800549CD9 /* ThemeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeButton.swift; sourceTree = "<group>"; };
 		7AB3BC862ABF91C000549CD9 /* Defaults+Extension+Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Defaults+Extension+Colors.swift"; sourceTree = "<group>"; };
 		7AB3BC882AC0CB2300549CD9 /* ThemeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeView.swift; sourceTree = "<group>"; };
 		7AB3BC8A2AC0CBC300549CD9 /* ColorThemeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorThemeView.swift; sourceTree = "<group>"; };
@@ -420,7 +418,6 @@
 				7A65AAFF286CF818002D6DCA /* ShareButton.swift */,
 				7A65AB01286CFC53002D6DCA /* SupportButton.swift */,
 				7A868D172890814A009C92D6 /* DetailedTimeDisplayMode.swift */,
-				7AB3BC812ABF89F800549CD9 /* ThemeButton.swift */,
 				7AB3BC882AC0CB2300549CD9 /* ThemeView.swift */,
 				7AB3BC8A2AC0CBC300549CD9 /* ColorThemeView.swift */,
 			);
@@ -955,7 +952,6 @@
 				7AF56AE9286F32CD0068B467 /* SupportContactItem.swift in Sources */,
 				7AF56AF7286F32CD0068B467 /* SupportHighlightedSection.swift in Sources */,
 				7A7CD913287F2E760001C64F /* CreateFirstEvent.swift in Sources */,
-				7AB3BC822ABF89F800549CD9 /* ThemeButton.swift in Sources */,
 				C2B53D7A2869CA3B00407F40 /* AddItemForm.swift in Sources */,
 				C2B53D7E2869CA8300407F40 /* CategoryRectangleView.swift in Sources */,
 				7AF56AEE286F32CD0068B467 /* HighlightedItem.swift in Sources */,
@@ -1164,6 +1160,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1197,6 +1194,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/DaysSince/AppIcons/AppIcons.swift
+++ b/DaysSince/AppIcons/AppIcons.swift
@@ -5,12 +5,15 @@
 //  Created by Vicki Minerva on 6/29/22.
 //
 
+import Defaults
 import SwiftUI
 
 struct AppIcons: View {
     @Environment(\.dismiss) var dismiss
 //    @EnvironmentObject var store: Store
 //    @EnvironmentObject var reviewManager: ReviewManager
+
+    @Default(.mainColor) var mainColor
 
     var columns: [GridItem] = [
         GridItem(.flexible(minimum: 100), spacing: 10),
@@ -91,7 +94,7 @@ struct AppIcons: View {
                             Image(systemName: "checkmark.circle.fill")
                                 .font(.title)
                                 .foregroundColor(.white)
-                                .shadow(color: Color.workColor.opacity(0.1), radius: 5, x: 0, y: 0)
+                                .shadow(color: mainColor.opacity(0.1), radius: 5, x: 0, y: 0)
                         }
                         .padding(8)
 

--- a/DaysSince/Assets.xcassets/animalCrossingsBrown.colorset/Contents.json
+++ b/DaysSince/Assets.xcassets/animalCrossingsBrown.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.231",
+          "green" : "0.430",
+          "red" : "0.563"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.154",
+          "green" : "0.278",
+          "red" : "0.364"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaysSince/Assets.xcassets/animalCrossingsGreen.colorset/Contents.json
+++ b/DaysSince/Assets.xcassets/animalCrossingsGreen.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.718",
+          "green" : "0.991",
+          "red" : "0.706"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.466",
+          "green" : "0.635",
+          "red" : "0.455"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaysSince/Assets.xcassets/marioBlue.colorset/Contents.json
+++ b/DaysSince/Assets.xcassets/marioBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.863",
+          "green" : "0.412",
+          "red" : "0.177"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.684",
+          "green" : "0.323",
+          "red" : "0.136"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaysSince/Assets.xcassets/marioRed.colorset/Contents.json
+++ b/DaysSince/Assets.xcassets/marioRed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.286",
+          "green" : "0.303",
+          "red" : "0.884"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.206",
+          "green" : "0.218",
+          "red" : "0.618"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaysSince/Assets.xcassets/peachDarkPink.colorset/Contents.json
+++ b/DaysSince/Assets.xcassets/peachDarkPink.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.545",
+          "green" : "0.309",
+          "red" : "0.853"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.438",
+          "green" : "0.247",
+          "red" : "0.679"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaysSince/Assets.xcassets/peachLightPink.colorset/Contents.json
+++ b/DaysSince/Assets.xcassets/peachLightPink.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.835",
+          "green" : "0.680",
+          "red" : "0.909"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.678",
+          "green" : "0.542",
+          "red" : "0.730"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaysSince/Assets.xcassets/zeldaGreen.colorset/Contents.json
+++ b/DaysSince/Assets.xcassets/zeldaGreen.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0.416",
+          "green" : "0.559",
+          "red" : "0.435"
         }
       },
       "idiom" : "universal"
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0.312",
+          "green" : "0.416",
+          "red" : "0.320"
         }
       },
       "idiom" : "universal"

--- a/DaysSince/Assets.xcassets/zeldaYellow.colorset/Contents.json
+++ b/DaysSince/Assets.xcassets/zeldaYellow.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.682",
+          "green" : "0.889",
+          "red" : "0.924"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.511",
+          "green" : "0.657",
+          "red" : "0.682"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaysSince/CategoriesViews/CategoryRectangleView.swift
+++ b/DaysSince/CategoriesViews/CategoryRectangleView.swift
@@ -22,17 +22,15 @@ struct CategoryRectangleView: View {
             backgroundColor
             categoryBlockContent
         }
-        .clipShape(RoundedRectangle(cornerRadius: 25))
+        .clipShape(RoundedRectangle(cornerRadius: 24))
         .padding(.horizontal, 12)
         .padding(.vertical, 4)
         .shadow(color: selectedCategory == nil ? category.color : selectedCategory == category ? category.color : category.color.opacity(0.2), radius: 10, x: 0, y: 5)
     }
 
     var backgroundColor: some View {
-        withAnimation {
-            category.color
-                .opacity(selectedCategory == nil ? 1 : selectedCategory == category ? 1 : 0.7)
-        }
+        category.color
+            .opacity(selectedCategory == nil ? 1 : selectedCategory == category ? 1 : 0.7)
     }
 
     var categoryBlockContent: some View {

--- a/DaysSince/DaysSince/MainScreen/MainScreen.swift
+++ b/DaysSince/DaysSince/MainScreen/MainScreen.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct MainScreen: View {
     @Default(.mainColor) var mainColor
+    @Default(.backgroundColor) var backgroundColor
 
     @Environment(\.colorScheme) var colorScheme
 
@@ -92,13 +93,13 @@ struct MainScreen: View {
             AddItemSheet(selectedCategory: nil, remindersEnabled: false, items: $items)
         }
         .sheet(isPresented: $showSettings) {
-            SettingsScreen(isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed, showSettings: $showSettings, showThemeSheet: $showThemeSheet)
+            SettingsScreen(isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed, showSettings: $showSettings)
         }
         .sheet(isPresented: $showThemeSheet) {
             ThemeView()
                 .presentationDetents([.medium])
+                .presentationCornerRadius(32)
                 .onDisappear { showThemeSheet = false }
-                .transition(.move(edge: .bottom))
         }
     }
 
@@ -109,15 +110,27 @@ struct MainScreen: View {
                     showSettings = true
                 } label: {
                     Image(systemName: "gearshape.fill")
-                        .foregroundColor(colorScheme == .dark ? .primary : .workColor.opacity(0.8))
+                        .foregroundColor(colorScheme == .dark ? .primary : mainColor.opacity(0.8))
                         .imageScale(.large)
                         .accessibilityLabel("Settings")
                         .font(.title2)
                 }
             }
 
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .navigationBarLeading) {
                 SortingMenuView(items: $items)
+            }
+
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    showThemeSheet = true
+                } label: {
+                    Image(systemName: "paintpalette.fill")
+                        .foregroundColor(colorScheme == .dark ? .primary : mainColor.opacity(0.8))
+                        .imageScale(.large)
+                        .accessibilityLabel("Change theme")
+                        .font(.title2)
+                }
             }
         }
     }
@@ -143,7 +156,7 @@ struct MainScreen: View {
             ))
             .background(colorScheme == .dark ? Color.black : Color.white)
             .clipShape(Capsule())
-            .shadow(color: Color.workColor, radius: 10, x: 0, y: 5)
+            .shadow(color: mainColor, radius: 10, x: 0, y: 5)
         }
         .buttonStyle(PlainButtonStyle())
         .padding(.bottom, 16)

--- a/DaysSince/DaysSince/MainScreen/Views/MainBackgroundView.swift
+++ b/DaysSince/DaysSince/MainScreen/Views/MainBackgroundView.swift
@@ -5,10 +5,13 @@
 //  Created by Vicki Minerva on 5/23/22.
 //
 
+import Defaults
 import SwiftUI
 
 struct MainBackgroundView: View {
     @Environment(\.colorScheme) var colorScheme
+
+    @Default(.backgroundColor) var backgroundColor
 
     var body: some View {
         if colorScheme == .dark {
@@ -16,7 +19,7 @@ struct MainBackgroundView: View {
                 .ignoresSafeArea()
         } else {
             LinearGradient(
-                gradient: .init(colors: [Color.backgroundColor.opacity(0.0), Color.backgroundColor]),
+                gradient: .init(colors: [backgroundColor.opacity(0.0), backgroundColor]),
                 startPoint: .init(x: 1, y: 0),
                 endPoint: .init(x: 0.0001, y: 0)
             )

--- a/DaysSince/DaysSince/MainScreen/Views/SortingMenuView.swift
+++ b/DaysSince/DaysSince/MainScreen/Views/SortingMenuView.swift
@@ -5,6 +5,7 @@
 //  Created by Vicki Minerva on 4/4/22.
 //
 
+import Defaults
 import SwiftUI
 
 enum SortType: String, CaseIterable, Identifiable {
@@ -13,7 +14,7 @@ enum SortType: String, CaseIterable, Identifiable {
     case daysAscending
     case daysDescending
     case category
-    case created
+//    case created
 
     var id: String { rawValue }
 
@@ -24,13 +25,13 @@ enum SortType: String, CaseIterable, Identifiable {
         case .alphabeticallyDescending:
             return "Alphabetical (Z-A)"
         case .daysAscending:
-            return "Days (Old-New)"
-        case .daysDescending:
             return "Days (New-Old)"
+        case .daysDescending:
+            return "Days (Old-New)"
         case .category:
             return "Category"
-        case .created:
-            return "Created"
+//        case .created:
+//            return "Created"
         }
     }
 
@@ -39,15 +40,15 @@ enum SortType: String, CaseIterable, Identifiable {
         case .alphabeticallyAscending:
             return itemOne.name < itemTwo.name
         case .alphabeticallyDescending:
-            return itemOne.name < itemTwo.name
+            return itemOne.name > itemTwo.name
         case .daysAscending:
             return itemOne.daysAgo < itemTwo.daysAgo
         case .daysDescending:
             return itemOne.daysAgo > itemTwo.daysAgo
         case .category:
             return itemOne.category.name > itemTwo.category.name
-        case .created:
-            return true
+//        case .created:
+//            return true
         }
     }
 }
@@ -63,6 +64,8 @@ struct SortingMenuView: View {
 
     @AppStorage("selectedSortType") var selectedSortType: SortType = .daysAscending
 
+    @Default(.mainColor) var mainColor
+
     var body: some View {
         Menu {
             ForEach(SortType.allCases) { type in
@@ -72,7 +75,7 @@ struct SortingMenuView: View {
                     Label(
                         type.name,
                         systemImage:
-                        type == selectedSortType ? "checkmark.circle.fill" : ""
+                        type == selectedSortType ? "checkmark" : ""
                     )
                 }
             }
@@ -80,7 +83,7 @@ struct SortingMenuView: View {
             Image(systemName: "arrow.up.arrow.down.circle.fill")
                 .imageScale(.large)
                 .font(.title2)
-                .foregroundColor(colorScheme == .dark ? .primary : .workColor.opacity(0.8))
+                .foregroundColor(colorScheme == .dark ? .primary : mainColor.opacity(0.8))
         }
         .foregroundColor(.primary)
         .accessibilityLabel("Sorting Menu")

--- a/DaysSince/DaysSince/MainScreen/Views/TopSection/MenuBlockView.swift
+++ b/DaysSince/DaysSince/MainScreen/Views/TopSection/MenuBlockView.swift
@@ -80,7 +80,7 @@ struct MenuBlockView: View {
     }
 
     var itemCount: some View {
-        Text("\(findItemCount()) events")
+        Text("^[\(findItemCount()) event](inflect: true)")
             .font(.system(.caption, design: .rounded))
     }
 

--- a/DaysSince/Extensions/Color+Extensions.swift
+++ b/DaysSince/Extensions/Color+Extensions.swift
@@ -9,11 +9,19 @@ import Foundation
 import SwiftUI
 
 extension Color {
-    static let workColor = Color("workColor") // "ppBlue")
-    static let lifeColor = Color("lifeColor") // "ppBlue")
+    static let workColor = Color("workColor")
+    static let lifeColor = Color("lifeColor")
     static let hobbiesColor = Color("hobbiesColor")
     static let healthColor = Color("healthColor")
     static let backgroundColor = Color("backgroundColor")
+    static let peachLightPink = Color("peachLightPink")
+    static let peachDarkPink = Color("peachDarkPink")
+    static let marioBlue = Color("marioBlue")
+    static let marioRed = Color("marioRed")
+    static let zeldaGreen = Color("zeldaGreen")
+    static let zeldaYellow = Color("zeldaYellow")
+    static let animalCrossingsBrown = Color("animalCrossingsBrown")
+    static let animalCrossingsGreen = Color("animalCrossingsGreen")
 
     public func lighter(by amount: CGFloat = 0.2) -> Self { Self(UIColor(self).lighter(by: amount)) }
     public func darker(by amount: CGFloat = 0.2) -> Self { Self(UIColor(self).darker(by: amount)) }

--- a/DaysSince/Onboarding/Pages/Introduction.swift
+++ b/DaysSince/Onboarding/Pages/Introduction.swift
@@ -25,7 +25,7 @@ struct Introduction: View {
     @State var colors = [
         Color.workColor,
         Color.lifeColor,
-        Color.hobbiesColor,
+        Color.hobbiesColor
     ]
 
     @State var currentIndex: Int = 2

--- a/DaysSince/Settings/ColorThemeView.swift
+++ b/DaysSince/Settings/ColorThemeView.swift
@@ -16,31 +16,41 @@ struct ColorThemeView: View {
     let backgroundColorTemporary: Color
 
     var body: some View {
-        Circle()
-            .frame(width: 72, height: 72)
-            .overlay {
-                LinearGradient(stops: [
-                    Gradient.Stop(color: mainColorTemporary, location: 0),
-                    Gradient.Stop(color: mainColorTemporary, location: 0.5),
-                    Gradient.Stop(color: backgroundColorTemporary, location: 0.5),
-                    Gradient.Stop(color: backgroundColorTemporary, location: 1),
-                ], startPoint: .topLeading, endPoint: .bottomTrailing)
-            }
-            .clipShape(Circle())
-            .onTapGesture {
-                let generator = UIImpactFeedbackGenerator(style: .medium)
-                generator.impactOccurred()
+        VStack {
+            Circle()
+                .frame(width: 72, height: 72)
+                .overlay {
+                    LinearGradient(stops: [
+                        Gradient.Stop(color: mainColorTemporary, location: 0),
+                        Gradient.Stop(color: mainColorTemporary, location: 0.5),
+                        Gradient.Stop(color: backgroundColorTemporary, location: 0.5),
+                        Gradient.Stop(color: backgroundColorTemporary, location: 1),
+                    ], startPoint: .topLeading, endPoint: .bottomTrailing)
+                }
+                .overlay((colorEquals("Main", mainColorTemporary, mainColor) || colorEquals("Background", backgroundColorTemporary, backgroundColor)) ? .clear : Color.black.opacity(0.2))
+                .clipShape(RoundedRectangle(cornerRadius: 24))
+                .onTapGesture {
+                    let generator = UIImpactFeedbackGenerator(style: .medium)
+                    generator.impactOccurred()
 
-                withAnimation {
                     mainColor = mainColorTemporary
+
                     backgroundColor = backgroundColorTemporary
                 }
-            }
+        }
+    }
+
+    func colorEquals(_ x: String, _ color1: Color, _ color2: Color) -> Bool {
+        let uiColor1 = UIColor(color1)
+        let uiColor2 = UIColor(color2)
+
+        return uiColor1 == uiColor2
     }
 }
 
 struct ColorThemeView_Previews: PreviewProvider {
     static var previews: some View {
+        ColorThemeView(mainColorTemporary: Color.workColor, backgroundColorTemporary: Color.backgroundColor)
         ColorThemeView(mainColorTemporary: Color.workColor, backgroundColorTemporary: Color.backgroundColor)
     }
 }

--- a/DaysSince/Settings/DetailedTimeDisplayMode.swift
+++ b/DaysSince/Settings/DetailedTimeDisplayMode.swift
@@ -5,10 +5,13 @@
 //  Created by Vicki Minerva on 7/26/22.
 //
 
+import Defaults
 import SwiftUI
 
 struct DetailedTimeDisplayModeCell: View {
     @Binding var isDaysDisplayModeDetailed: Bool
+
+    @Default(.mainColor) var mainColor
 
     var body: some View {
         Section {
@@ -27,7 +30,7 @@ struct DetailedTimeDisplayModeCell: View {
     }
 
     var buttonImage: some View {
-        LinearGradient(colors: [Color.workColor, Color.workColor.lighter()], startPoint: .topLeading, endPoint: .bottomTrailing)
+        LinearGradient(colors: [mainColor, mainColor.lighter()], startPoint: .topLeading, endPoint: .bottomTrailing)
             .frame(width: 30, height: 30)
             .cornerRadius(8)
             .overlay(
@@ -46,7 +49,7 @@ struct DetailedTimeDisplayModeCell: View {
 
     var toggle: some View {
         Toggle("Detailed Time Display Mode", isOn: $isDaysDisplayModeDetailed)
-            .tint(Color.workColor)
+            .tint(mainColor)
             .labelsHidden()
     }
 }

--- a/DaysSince/Settings/SettingsReviewButton.swift
+++ b/DaysSince/Settings/SettingsReviewButton.swift
@@ -5,10 +5,12 @@
 //  Created by Vicki Minerva on 6/30/22.
 //
 
+import Defaults
 import SwiftUI
 
 struct SettingsReviewButton: View {
     @Environment(\.openURL) var openURL
+    @Default(.mainColor) var mainColor
 
     var body: some View {
         Button {
@@ -27,7 +29,7 @@ struct SettingsReviewButton: View {
     }
 
     var buttonImage: some View {
-        LinearGradient(colors: [Color.workColor, Color.workColor.lighter()], startPoint: .topLeading, endPoint: .bottomTrailing)
+        LinearGradient(colors: [mainColor, mainColor.lighter()], startPoint: .topLeading, endPoint: .bottomTrailing)
             .frame(width: 34, height: 34)
             .cornerRadius(8)
             .overlay(
@@ -46,7 +48,7 @@ struct SettingsReviewButton: View {
     var buttonShareArrow: some View {
         Image(systemName: "arrow.up.forward.app.fill")
             .font(.title2)
-            .foregroundColor(Color.workColor.darker())
+            .foregroundColor(mainColor.darker())
             .opacity(0.5)
     }
 }

--- a/DaysSince/Settings/SettingsScreen.swift
+++ b/DaysSince/Settings/SettingsScreen.swift
@@ -15,7 +15,6 @@ struct SettingsScreen: View {
 
     @Binding var isDaysDisplayModeDetailed: Bool
     @Binding var showSettings: Bool
-    @Binding var showThemeSheet: Bool
 
     var body: some View {
         NavigationView {
@@ -23,7 +22,6 @@ struct SettingsScreen: View {
 //                daysSinceProSection
                 appIconsSection
 
-                ThemeButton(showSettings: $showSettings, showThemeSheet: $showThemeSheet)
                 DetailedTimeDisplayModeCell(isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed)
 
                 Section {
@@ -43,19 +41,13 @@ struct SettingsScreen: View {
                     } label: {
                         Image(systemName: "chevron.down.circle.fill")
                             .font(.title2)
-                            .foregroundColor(Color.workColor.opacity(0.8))
+                            .foregroundColor(mainColor.opacity(0.8))
                             .accessibilityLabel("Dismiss")
                     }
                 }
             })
         }
-        .onAppear {
-            print("Appear showThemeSheet", showThemeSheet)
-        }
-        .onDisappear {
-            print("Disappear showThemeSheet", showThemeSheet)
-        }
-        .accentColor(Color.workColor.darker())
+        .accentColor(mainColor.darker())
     }
 
     var daysSinceProSection: some View {
@@ -67,7 +59,7 @@ struct SettingsScreen: View {
                 .frame(height: 120)
                 .listRowBackground(
                     ZStack(alignment: .leading) {
-                        Color.workColor
+                        mainColor
 
                         Text("Days Since\nPro")
                             .font(.system(.title, design: .rounded))
@@ -136,6 +128,9 @@ struct SettingsScreen: View {
 
 struct SettingsScreen_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsScreen(isDaysDisplayModeDetailed: .constant(false), showSettings: .constant(true), showThemeSheet: .constant(false))
+        SettingsScreen(
+            isDaysDisplayModeDetailed: .constant(false),
+            showSettings: .constant(true)
+        )
     }
 }

--- a/DaysSince/Settings/ShareButton.swift
+++ b/DaysSince/Settings/ShareButton.swift
@@ -5,10 +5,13 @@
 //  Created by Vicki Minerva on 6/30/22.
 //
 
+import Defaults
 import SwiftUI
 
 struct ShareButton: View {
     @State var showShare = false
+
+    @Default(.mainColor) var mainColor
 
     var body: some View {
         Button {
@@ -28,7 +31,7 @@ struct ShareButton: View {
     }
 
     var buttonImage: some View {
-        LinearGradient(colors: [Color.workColor, Color.workColor.lighter()], startPoint: .topLeading, endPoint: .bottomTrailing)
+        LinearGradient(colors: [mainColor, mainColor.lighter()], startPoint: .topLeading, endPoint: .bottomTrailing)
             .frame(width: 34, height: 34)
             .cornerRadius(8)
             .overlay(
@@ -47,7 +50,7 @@ struct ShareButton: View {
     var buttonShareArrow: some View {
         Image(systemName: "arrow.up.forward.app.fill")
             .font(.title2)
-            .foregroundColor(Color.workColor.darker())
+            .foregroundColor(mainColor.darker())
             .opacity(0.5)
     }
 }

--- a/DaysSince/Settings/SupportButton.swift
+++ b/DaysSince/Settings/SupportButton.swift
@@ -5,16 +5,19 @@
 //  Created by Vicki Minerva on 6/30/22.
 //
 
+import Defaults
 import SwiftUI
 
 struct SupportButton: View {
+    @Default(.mainColor) var mainColor
+
     var body: some View {
         NavigationLink {
             SupportScreen()
                 .interactiveDismissDisabled()
         } label: {
             HStack {
-                LinearGradient(colors: [Color.workColor, Color.workColor.lighter()], startPoint: .topLeading, endPoint: .bottomTrailing)
+                LinearGradient(colors: [mainColor, mainColor.lighter()], startPoint: .topLeading, endPoint: .bottomTrailing)
                     .frame(width: 34, height: 34)
                     .cornerRadius(8)
                     .overlay(

--- a/DaysSince/Settings/ThemeButton.swift
+++ b/DaysSince/Settings/ThemeButton.swift
@@ -31,7 +31,7 @@ struct ThemeButton: View {
     }
 
     var buttonImage: some View {
-        LinearGradient(colors: [Color.workColor, Color.workColor.lighter()], startPoint: .topLeading, endPoint: .bottomTrailing)
+        LinearGradient(colors: [mainColor, mainColor.lighter()], startPoint: .topLeading, endPoint: .bottomTrailing)
             .frame(width: 30, height: 30)
             .cornerRadius(8)
             .overlay(

--- a/DaysSince/Settings/ThemeView.swift
+++ b/DaysSince/Settings/ThemeView.swift
@@ -15,33 +15,59 @@ struct ThemeView: View {
         GridItem(.flexible(minimum: 56), spacing: 10),
     ]
 
+    let colorThemes: [ColorTheme] = [
+        ColorTheme(mainColor: .workColor.darker(by: 0.02), backgroundColor: .backgroundColor),
+        ColorTheme(mainColor: .healthColor.darker(by: 0.2), backgroundColor: .healthColor.lighter(by: 0.4)),
+        ColorTheme(mainColor: .lifeColor.darker(by: 0.2), backgroundColor: .lifeColor.lighter(by: 0.4)),
+        ColorTheme(mainColor: .hobbiesColor.darker(by: 0.2), backgroundColor: .hobbiesColor.lighter(by: 0.4)),
+        ColorTheme(mainColor: .zeldaGreen.darker(by: 0.1), backgroundColor: .zeldaYellow),
+        ColorTheme(mainColor: .black, backgroundColor: .backgroundColor),
+        ColorTheme(mainColor: .marioRed, backgroundColor: .marioBlue.lighter(by: 0.6)),
+        ColorTheme(mainColor: .peachDarkPink.darker(by: 0.1), backgroundColor: .peachLightPink),
+//        ColorTheme(mainColor: .green, backgroundColor: .brown.lighter(by: 0.6)),
+        ColorTheme(mainColor: .marioRed, backgroundColor: .marioRed.lighter(by: 0.8)),
+        ColorTheme(mainColor: .animalCrossingsBrown, backgroundColor: .animalCrossingsGreen.lighter(by: 0.6)),
+    ]
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack {
+            HStack(alignment: .center) {
+                Spacer()
                 Text("Colors")
-                    .font(.system(.title2, design: .rounded))
+                    .font(.system(.headline, design: .rounded))
                     .bold()
                     .padding(.horizontal, 24)
+                Spacer()
             }
 
-            .padding(.top, 8)
+            .padding(.top, 20)
 
             LazyVGrid(
                 columns: columns,
                 alignment: .center,
                 spacing: 20
             ) {
-                ColorThemeView(mainColorTemporary: Color.workColor, backgroundColorTemporary: Color.backgroundColor)
-                ColorThemeView(mainColorTemporary: Color.lifeColor, backgroundColorTemporary: Color.lifeColor)
-                ColorThemeView(mainColorTemporary: Color.healthColor, backgroundColorTemporary: Color.healthColor)
-                ColorThemeView(mainColorTemporary: Color.hobbiesColor, backgroundColorTemporary: Color.hobbiesColor)
-                ColorThemeView(mainColorTemporary: Color.black, backgroundColorTemporary: Color.pink)
-                ColorThemeView(mainColorTemporary: Color.yellow, backgroundColorTemporary: Color.gray)
+                ForEach(colorThemes, id: \.self) { colorTheme in
+                    ColorThemeView(
+                        mainColorTemporary: colorTheme.mainColor,
+                        backgroundColorTemporary: colorTheme.backgroundColor
+                    )
+                }
             }
             .padding()
 
             Spacer()
         }
+    }
+}
+
+struct ColorTheme: Equatable, Hashable {
+    let mainColor: Color
+    let backgroundColor: Color
+
+    // Implement the equality operator
+    static func == (lhs: ColorTheme, rhs: ColorTheme) -> Bool {
+        return lhs.mainColor == rhs.mainColor && lhs.backgroundColor == rhs.backgroundColor
     }
 }
 


### PR DESCRIPTION
Implemented the sheeet to customize the colors of the app. The sheet is presented from a toolbar item in the trailing of the navigation bar of the main screen. This was a change in the UI but I believe it makes sense to have it on the main screen. The current theme is a highlighted rounded rectangle in the sheet. Many of the color themes were inspired by Nintendo: Zelda, Mario, Princess Peach, and Animal Crossings. This screen can be expanded to also select background patterns for example. 