### PR TITLE
Customize Categories Feature

### DIFF
--- a/DaysSince.xcodeproj/project.pbxproj
+++ b/DaysSince.xcodeproj/project.pbxproj
@@ -28,7 +28,18 @@
 		7A7CD911287F22E90001C64F /* AnimateText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7CD910287F22E90001C64F /* AnimateText.swift */; };
 		7A7CD913287F2E760001C64F /* CreateFirstEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7CD912287F2E760001C64F /* CreateFirstEvent.swift */; };
 		7A868D182890814A009C92D6 /* DetailedTimeDisplayMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A868D172890814A009C92D6 /* DetailedTimeDisplayMode.swift */; };
+		7A9141B42B0EA6AF00F06CA2 /* CategoryColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9141B32B0EA6AF00F06CA2 /* CategoryColor.swift */; };
+		7A9141B52B0EA6AF00F06CA2 /* CategoryColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9141B32B0EA6AF00F06CA2 /* CategoryColor.swift */; };
+		7A9141B62B0EA6AF00F06CA2 /* CategoryColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9141B32B0EA6AF00F06CA2 /* CategoryColor.swift */; };
+		7A9141B82B0EA6E300F06CA2 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9141B72B0EA6E300F06CA2 /* Category.swift */; };
+		7A9141B92B0EA6E300F06CA2 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9141B72B0EA6E300F06CA2 /* Category.swift */; };
+		7A9141BA2B0EA6E300F06CA2 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9141B72B0EA6E300F06CA2 /* Category.swift */; };
+		7A9141BC2B0EA6FE00F06CA2 /* Defaults in Frameworks */ = {isa = PBXBuildFile; productRef = 7A9141BB2B0EA6FE00F06CA2 /* Defaults */; };
+		7A9141BE2B0EA7C300F06CA2 /* Defaults in Frameworks */ = {isa = PBXBuildFile; productRef = 7A9141BD2B0EA7C300F06CA2 /* Defaults */; };
+		7A9141C02B111B6E00F06CA2 /* CategoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9141BF2B111B6D00F06CA2 /* CategoryManager.swift */; };
+		7A9141C22B12555B00F06CA2 /* CategoryFormSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9141C12B12555B00F06CA2 /* CategoryFormSection.swift */; };
 		7AAB507727FF86CC0086A5A8 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AAB507627FF86CC0086A5A8 /* Defaults.swift */; };
+		7AADEB652B12897000A7CF25 /* AddCategorySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AADEB642B12897000A7CF25 /* AddCategorySheet.swift */; };
 		7AB3BC852ABF917C00549CD9 /* Defaults in Frameworks */ = {isa = PBXBuildFile; productRef = 7AB3BC842ABF917C00549CD9 /* Defaults */; };
 		7AB3BC872ABF91C000549CD9 /* Defaults+Extension+Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB3BC862ABF91C000549CD9 /* Defaults+Extension+Colors.swift */; };
 		7AB3BC892AC0CB2300549CD9 /* ThemeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB3BC882AC0CB2300549CD9 /* ThemeView.swift */; };
@@ -177,8 +188,13 @@
 		7A7CD910287F22E90001C64F /* AnimateText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimateText.swift; sourceTree = "<group>"; };
 		7A7CD912287F2E760001C64F /* CreateFirstEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFirstEvent.swift; sourceTree = "<group>"; };
 		7A868D172890814A009C92D6 /* DetailedTimeDisplayMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailedTimeDisplayMode.swift; sourceTree = "<group>"; };
+		7A9141B32B0EA6AF00F06CA2 /* CategoryColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryColor.swift; sourceTree = "<group>"; };
+		7A9141B72B0EA6E300F06CA2 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
+		7A9141BF2B111B6D00F06CA2 /* CategoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryManager.swift; sourceTree = "<group>"; };
+		7A9141C12B12555B00F06CA2 /* CategoryFormSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryFormSection.swift; sourceTree = "<group>"; };
 		7AAB507327FF860C0086A5A8 /* Defaults */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Defaults; path = "../../../../../Library/Developer/Xcode/DerivedData/Posture_Pal-baxwxadtvwjgulhdvdslumckelkv/SourcePackages/checkouts/Defaults"; sourceTree = "<group>"; };
 		7AAB507627FF86CC0086A5A8 /* Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
+		7AADEB642B12897000A7CF25 /* AddCategorySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCategorySheet.swift; sourceTree = "<group>"; };
 		7AB3BC862ABF91C000549CD9 /* Defaults+Extension+Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Defaults+Extension+Colors.swift"; sourceTree = "<group>"; };
 		7AB3BC882AC0CB2300549CD9 /* ThemeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeView.swift; sourceTree = "<group>"; };
 		7AB3BC8A2AC0CBC300549CD9 /* ColorThemeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorThemeView.swift; sourceTree = "<group>"; };
@@ -276,6 +292,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7A9141BC2B0EA6FE00F06CA2 /* Defaults in Frameworks */,
 				C2B53DB12869F0CE00407F40 /* SwiftUI.framework in Frameworks */,
 				C2B53DAF2869F0CE00407F40 /* WidgetKit.framework in Frameworks */,
 			);
@@ -285,6 +302,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7A9141BE2B0EA7C300F06CA2 /* Defaults in Frameworks */,
 				C2B53DCD2869F6F200407F40 /* Intents.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -324,6 +342,7 @@
 				7A2A76F327F2446E006F0470 /* DaysSinceApp.swift */,
 				7A2A76F527F2446E006F0470 /* ContentView.swift */,
 				C21BDC57286F355200B2FDCC /* NotificationManager.swift */,
+				7A9141BF2B111B6D00F06CA2 /* CategoryManager.swift */,
 				7AAB507027FF83CC0086A5A8 /* Screens */,
 				7A2A76F727F24470006F0470 /* Assets.xcassets */,
 				7A2A76F927F24470006F0470 /* Preview Content */,
@@ -349,6 +368,8 @@
 				C2B53D742869CA1000407F40 /* CategoryDSItem.swift */,
 				7AAB507627FF86CC0086A5A8 /* Defaults.swift */,
 				7AE8E366286C948200538521 /* AlternativeIcon.swift */,
+				7A9141B32B0EA6AF00F06CA2 /* CategoryColor.swift */,
+				7A9141B72B0EA6E300F06CA2 /* Category.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -623,6 +644,8 @@
 			children = (
 				7A2A770827F2592D006F0470 /* AddItemSheet.swift */,
 				C2B53D792869CA3B00407F40 /* AddItemForm.swift */,
+				7A9141C12B12555B00F06CA2 /* CategoryFormSection.swift */,
+				7AADEB642B12897000A7CF25 /* AddCategorySheet.swift */,
 			);
 			path = AddItemViews;
 			sourceTree = "<group>";
@@ -755,6 +778,9 @@
 			dependencies = (
 			);
 			name = WidgetExtension;
+			packageProductDependencies = (
+				7A9141BB2B0EA6FE00F06CA2 /* Defaults */,
+			);
 			productName = WidgetExtension;
 			productReference = C2B53DAC2869F0CE00407F40 /* WidgetExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -772,6 +798,9 @@
 			dependencies = (
 			);
 			name = WidgetIntents;
+			packageProductDependencies = (
+				7A9141BD2B0EA7C300F06CA2 /* Defaults */,
+			);
 			productName = WidgetIntents;
 			productReference = C2B53DCB2869F6F200407F40 /* WidgetIntents.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -890,8 +919,10 @@
 				C2B53D9B2869CACA00407F40 /* MenuBlockView.swift in Sources */,
 				7AF56AFD286F32CD0068B467 /* ChangelogView.swift in Sources */,
 				C21BDC58286F355200B2FDCC /* NotificationManager.swift in Sources */,
+				7A9141C22B12555B00F06CA2 /* CategoryFormSection.swift in Sources */,
 				C2B53D752869CA1000407F40 /* CategoryDSItem.swift in Sources */,
 				7A2A76F627F2446E006F0470 /* ContentView.swift in Sources */,
+				7A9141B82B0EA6E300F06CA2 /* Category.swift in Sources */,
 				7AB3BC892AC0CB2300549CD9 /* ThemeView.swift in Sources */,
 				C2B53D7C2869CA5800407F40 /* CategoriesGridView.swift in Sources */,
 				7AF56AFC286F32CD0068B467 /* NewUpdateBanner.swift in Sources */,
@@ -907,6 +938,7 @@
 				7AF56AEA286F32CD0068B467 /* FAQItem.swift in Sources */,
 				7AF56ADD286F32CD0068B467 /* SupportItemDetailView.swift in Sources */,
 				7AF56AE5286F32CD0068B467 /* SupportItemable.swift in Sources */,
+				7AADEB652B12897000A7CF25 /* AddCategorySheet.swift in Sources */,
 				C2B53D912869CACA00407F40 /* MainBackgroundView.swift in Sources */,
 				C2B53D992869CACA00407F40 /* TopSection.swift in Sources */,
 				7AF56AF3286F32CD0068B467 /* SupportContactSection.swift in Sources */,
@@ -946,6 +978,8 @@
 				7AF56AF5286F32CD0068B467 /* FAQItemView.swift in Sources */,
 				7AF56AF0286F32CD0068B467 /* SupportItemPage.swift in Sources */,
 				7A21765927FB2E3E006B106B /* EditTappedItemSheet.swift in Sources */,
+				7A9141C02B111B6E00F06CA2 /* CategoryManager.swift in Sources */,
+				7A9141B42B0EA6AF00F06CA2 /* CategoryColor.swift in Sources */,
 				7AF56AE2286F32CD0068B467 /* BackPortedAsyncImage.swift in Sources */,
 				7AE8E362286C921200538521 /* SettingsScreen.swift in Sources */,
 				7AF56AF1286F32CD0068B467 /* SupportColor.swift in Sources */,
@@ -970,6 +1004,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7A9141B52B0EA6AF00F06CA2 /* CategoryColor.swift in Sources */,
+				7A9141B92B0EA6E300F06CA2 /* Category.swift in Sources */,
 				C255EB68289A725100282E7B /* Widget.intentdefinition in Sources */,
 				C2B53DB42869F0CE00407F40 /* Widget.swift in Sources */,
 				C2B53DC42869F35B00407F40 /* DSItemReminders.swift in Sources */,
@@ -985,6 +1021,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7A9141B62B0EA6AF00F06CA2 /* CategoryColor.swift in Sources */,
+				7A9141BA2B0EA6E300F06CA2 /* Category.swift in Sources */,
 				C2B53DD82869F70E00407F40 /* DSItem.swift in Sources */,
 				C2B53DD92869F71300407F40 /* CategoryDSItem.swift in Sources */,
 				C2B53DDB2869F72400407F40 /* DSItemReminders.swift in Sources */,
@@ -1373,6 +1411,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		7A9141BB2B0EA6FE00F06CA2 /* Defaults */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7AB3BC832ABF917C00549CD9 /* XCRemoteSwiftPackageReference "Defaults" */;
+			productName = Defaults;
+		};
+		7A9141BD2B0EA7C300F06CA2 /* Defaults */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7AB3BC832ABF917C00549CD9 /* XCRemoteSwiftPackageReference "Defaults" */;
+			productName = Defaults;
+		};
 		7AB3BC842ABF917C00549CD9 /* Defaults */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 7AB3BC832ABF917C00549CD9 /* XCRemoteSwiftPackageReference "Defaults" */;

--- a/DaysSince/AddItemViews/AddCategorySheet.swift
+++ b/DaysSince/AddItemViews/AddCategorySheet.swift
@@ -1,0 +1,173 @@
+//
+//  AddCategorySheet.swift
+//  DaysSince
+//
+//  Created by Vicki Minerva on 11/25/23.
+//
+
+import Defaults
+import SwiftUI
+
+struct AddCategorySheet: View {
+    @Default(.categories) var categories
+
+    @State var selectedName: String = ""
+    @State var selectedColor: CategoryColor = .work
+    @State var selectedEmoji: String = "lightbulb"
+
+    @Environment(\.dismiss) var dismiss
+    @EnvironmentObject var categoriesManager: CategoryManager
+
+    var emojis: [String] = ["lightbulb", "leaf", "gamecontroller", "heart.text.square", "graduationcap", "bell", "gift.fill", "heart", "laptopcomputer", "airplane"]
+
+    var body: some View {
+        ScrollView {
+            header
+            name
+            emoji
+            color
+        }
+        .padding(.horizontal, 16)
+    }
+
+    var header: some View {
+        ZStack {
+            HStack {
+                Spacer()
+
+                VStack(spacing: 4) {
+                    Text("New Category")
+                        .font(.system(.body, design: .rounded))
+                        .bold()
+
+                    // Custom divider elebent
+                    RoundedRectangle(cornerRadius: 4)
+                        .frame(width: 72, height: 2)
+                        .opacity(0.5)
+                }
+                .foregroundColor(Color.primary.opacity(0.4))
+                Spacer()
+            }
+            HStack {
+                Spacer()
+
+                Button {
+                    categoriesManager.addCategory(name: selectedName, emoji: selectedEmoji, color: selectedColor)
+                    dismiss()
+                } label: {
+                    Text("Add")
+                        .bold()
+                        .foregroundColor(isCategoryCreationValid ? accentColor : Color.gray)
+                        .padding(8)
+                        .padding(.horizontal, 8)
+                        .background(isCategoryCreationValid ? accentColor.opacity(0.16).cornerRadius(20) : Color.gray.opacity(0.16).cornerRadius(20))
+                }
+                .disabled(selectedName.isEmpty)
+            }
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 8)
+    }
+
+    var name: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("NAME")
+                .font(.caption)
+                .opacity(0.6)
+                .padding(.leading, 20)
+
+            HStack {
+                TextField("Enter category name", text: $selectedName)
+
+                Spacer()
+            }
+            .padding(12)
+            .background(Color.secondary.opacity(0.1))
+            .cornerRadius(20)
+        }
+    }
+
+    var columns: [GridItem] = [
+        GridItem(.adaptive(minimum: 50, maximum: 50), spacing: 24),
+    ]
+
+    var emoji: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("EMOJI")
+                .font(.caption)
+                .opacity(0.6)
+                .padding(.leading, 20)
+
+            LazyVGrid(
+                columns: columns,
+                alignment: .center,
+                spacing: 20
+            ) {
+                ForEach(emojis, id: \.self) { emoji in
+                    Button {
+                        selectedEmoji = emoji
+                    } label: {
+                        Image(systemName: emoji)
+                            .font(.title)
+                            .foregroundColor(selectedEmoji == emoji ? accentColor : .primary)
+                            .padding(12)
+                            .background(accentColor.opacity(0.16).opacity(selectedEmoji == emoji ? 1 : 0))
+                            .cornerRadius(20)
+                    }
+                }
+            }
+            .padding(12)
+            .padding(.vertical, 6)
+            .background(Color.secondary.opacity(0.1))
+            .cornerRadius(16)
+        }
+        .padding(.horizontal, 4)
+    }
+
+    var color: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("COLOR")
+                .font(.caption)
+                .opacity(0.6)
+                .padding(.leading, 20)
+
+            LazyVGrid(
+                columns: columns,
+                alignment: .center,
+                spacing: 20
+            ) {
+                ForEach(CategoryColor.allCases, id: \.self.id) { color in
+                    Button {
+                        selectedColor = color
+                    } label: {
+                        Image(systemName: selectedColor == color ? "app.fill" : "app")
+                            .font(.title)
+                            .bold()
+                            .foregroundColor(color.color)
+                    }
+                }
+            }
+            .padding(12)
+            .padding(.vertical, 6)
+            .background(Color.secondary.opacity(0.1))
+            .cornerRadius(16)
+        }
+        .padding(.horizontal, 4)
+    }
+
+    var isCategoryCreationValid: Bool {
+        return !selectedName.isEmpty
+    }
+
+    var buttonColor: Color {
+        return isCategoryCreationValid ? .accentColor : .gray
+    }
+
+    var accentColor: Color { selectedColor.color }
+}
+
+struct AddCategorySheet_Previews: PreviewProvider {
+    static var previews: some View {
+        AddCategorySheet()
+    }
+}

--- a/DaysSince/AddItemViews/AddItemSheet.swift
+++ b/DaysSince/AddItemViews/AddItemSheet.swift
@@ -5,38 +5,49 @@
 //  Created by Vicki Minerva on 3/28/22.
 //
 
+import Defaults
 import SwiftUI
 import UserNotifications
 
 struct AddItemSheet: View {
+    @Default(.categories) var categories
+
     @Environment(\.dismiss) var dismiss
 
     @EnvironmentObject var notificationManager: NotificationManager
 
     @State private var name: String = ""
     @State var date: Date = .now
-    @State var selectedCategory: CategoryDSItem? = nil
+    @State var selectedCategory: Category?
     @State var remindersEnabled: Bool = false
     @State var selectedReminder: DSItemReminders = .daily
+    @State var showCategorySheet = false
 
     @FocusState private var nameIsFocused: Bool
 
     @Binding var items: [DSItem]
 
     var accentColor: Color {
-        selectedCategory == nil ? Color.black : selectedCategory?.color as! Color
+        selectedCategory?.color.color ?? .primary
     }
 
     var body: some View {
         // Form
         NavigationView {
-            AddItemForm(items: $items, name: $name, date: $date, category: $selectedCategory, remindersEnabled: $remindersEnabled, selectedReminder: $selectedReminder, nameIsFocused: $nameIsFocused)
+            AddItemForm(items: $items, name: $name, date: $date, category: $selectedCategory, remindersEnabled: $remindersEnabled, showCategorySheet: $showCategorySheet, selectedReminder: $selectedReminder, nameIsFocused: $nameIsFocused)
                 .navigationTitle("New Event")
                 .navigationBarTitleDisplayMode(.inline)
                 .ignoresSafeArea(.keyboard, edges: .bottom)
                 .toolbar(content: {
                     toolbarItems
                 })
+        }
+        .sheet(isPresented: $showCategorySheet) {
+            AddCategorySheet()
+                .presentationDragIndicator(.hidden)
+                .presentationDetents([.medium])
+                .presentationCornerRadius(44)
+                .onDisappear { showCategorySheet = false }
         }
     }
 
@@ -49,7 +60,7 @@ struct AddItemSheet: View {
                     Image(systemName: "chevron.down.circle.fill")
                 }
                 .font(.title3)
-                .foregroundColor(self.selectedCategory != nil ? self.selectedCategory!.color : .primary)
+                .foregroundColor(accentColor)
             }
 
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -57,7 +68,7 @@ struct AddItemSheet: View {
                     let newItem = DSItem(
                         id: UUID(),
                         name: name,
-                        category: selectedCategory ?? .life,
+                        category: selectedCategory ?? categories.first!,
                         dateLastDone: date,
                         remindersEnabled: remindersEnabled
                     )
@@ -70,12 +81,11 @@ struct AddItemSheet: View {
 
                     print("➕ Added item. Now there are \(items.count) items!")
 
-                    if let itemAdded = items.last {}
                     dismiss()
                 } label: {
                     Text("Save")
                 }
-                .foregroundColor(name.isEmpty ? Color.gray : self.selectedCategory != nil ? self.selectedCategory!.color : .primary)
+                .foregroundColor(accentColor)
                 .disabled(name.isEmpty)
             }
 
@@ -86,7 +96,7 @@ struct AddItemSheet: View {
                     } label: {
                         Text("Done")
                     }
-                    .foregroundColor(self.selectedCategory != nil ? self.selectedCategory!.color : .primary)
+                    .foregroundColor(accentColor)
                 }
             }
         }
@@ -95,6 +105,6 @@ struct AddItemSheet: View {
 
 struct AddItemSheet_Previews: PreviewProvider {
     static var previews: some View {
-        AddItemSheet(selectedCategory: CategoryDSItem.work, items: .constant([]))
+        AddItemSheet(selectedCategory: Category.placeholderCategory(), items: .constant([]))
     }
 }

--- a/DaysSince/AddItemViews/CategoryFormSection.swift
+++ b/DaysSince/AddItemViews/CategoryFormSection.swift
@@ -1,0 +1,78 @@
+//
+//  CategoryFormSection.swift
+//  DaysSince
+//
+//  Created by Vicki Minerva on 11/25/23.
+//
+
+import Defaults
+import SwiftUI
+
+struct CategoryFormSection: View {
+    @Default(.categories) var categories
+
+    @Binding var selectedCategory: Category?
+    @Binding var showCategorySheet: Bool
+
+    var accentColor: Color { selectedCategory?.color.color ?? Color.black }
+
+    var body: some View {
+        Section {
+            categoriesList
+            addCategoryButton
+        } header: {
+            Text("Category")
+        }
+    }
+
+    var categoriesList: some View {
+        ForEach(categories, id: \.id) { category in
+            Button {
+                withAnimation { selectedCategory = category }
+            } label: {
+                HStack {
+                    Image(systemName: category.emoji)
+                        .foregroundColor(selectedCategory == category ? accentColor : .primary)
+                        .frame(width: 40)
+
+                    Text(category.name)
+                    Spacer()
+
+                    if selectedCategory == category {
+                        Image(systemName: "checkmark.circle.fill")
+                            .imageScale(.large)
+                            .foregroundColor(accentColor)
+                    }
+                }
+            }
+            .foregroundColor(.primary)
+        }
+    }
+
+    var addCategoryButton: some View {
+        HStack {
+            Spacer()
+            Button {
+                showCategorySheet = true
+            } label: {
+                HStack {
+                    Image(systemName: "plus.rectangle.fill.on.rectangle.fill")
+                        .foregroundColor(.primary)
+                    Text("Add Category")
+                        .foregroundColor(.primary)
+                        .bold()
+                }
+            }
+            .padding()
+            .background(Color.primary.opacity(0.1))
+            .cornerRadius(16)
+        }
+        .buttonStyle(BorderlessButtonStyle())
+    }
+}
+
+struct CategoryFormSection_Previews: PreviewProvider {
+    static var previews: some View {
+        CategoryFormSection(selectedCategory: .constant(nil), showCategorySheet: .constant(false))
+    }
+}

--- a/DaysSince/CategoriesViews/CategoriesGridView.swift
+++ b/DaysSince/CategoriesViews/CategoriesGridView.swift
@@ -6,40 +6,40 @@
 //
 
 import SwiftUI
-
-struct CategoriesGridView: View {
-    @Binding var selectedCategory: CategoryDSItem?
-
-    @State var addItem: Bool
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 0) {
-            VStack {
-                CategoryRectangleView(category: .work, selectedCategory: selectedCategory)
-                    .onTapGesture {
-                        selectedCategory = .work
-                    }
-                CategoryRectangleView(category: .life, selectedCategory: selectedCategory)
-                    .onTapGesture {
-                        selectedCategory = .life
-                    }
-            }
-            VStack {
-                CategoryRectangleView(category: .health, selectedCategory: selectedCategory)
-                    .onTapGesture {
-                        selectedCategory = .health
-                    }
-                CategoryRectangleView(category: .hobbies, selectedCategory: selectedCategory)
-                    .onTapGesture {
-                        selectedCategory = .hobbies
-                    }
-            }
-        }
-    }
-}
-
-struct CategoriesGridView_Previews: PreviewProvider {
-    static var previews: some View {
-        CategoriesGridView(selectedCategory: .constant(CategoryDSItem.hobbies), addItem: true)
-    }
-}
+//
+// struct CategoriesGridView: View {
+//    @Binding var selectedCategory: CategoryDSItem?
+//
+//    @State var addItem: Bool
+//
+//    var body: some View {
+//        HStack(alignment: .top, spacing: 0) {
+//            VStack {
+//                CategoryRectangleView(category: .work, selectedCategory: selectedCategory)
+//                    .onTapGesture {
+//                        selectedCategory = .work
+//                    }
+//                CategoryRectangleView(category: .life, selectedCategory: selectedCategory)
+//                    .onTapGesture {
+//                        selectedCategory = .life
+//                    }
+//            }
+//            VStack {
+//                CategoryRectangleView(category: .health, selectedCategory: selectedCategory)
+//                    .onTapGesture {
+//                        selectedCategory = .health
+//                    }
+//                CategoryRectangleView(category: .hobbies, selectedCategory: selectedCategory)
+//                    .onTapGesture {
+//                        selectedCategory = .hobbies
+//                    }
+//            }
+//        }
+//    }
+// }
+//
+// struct CategoriesGridView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        CategoriesGridView(selectedCategory: .constant(CategoryDSItem.hobbies), addItem: true)
+//    }
+// }

--- a/DaysSince/CategoriesViews/CategoryFilteredView.swift
+++ b/DaysSince/CategoriesViews/CategoryFilteredView.swift
@@ -10,15 +10,20 @@ import SwiftUI
 struct CategoryFilteredView: View {
     @Environment(\.colorScheme) var colorScheme
 
-    var category: CategoryDSItem
+    var category: Category
 
     @State var showAddItemSheet: Bool
     @State var editItemSheet: Bool
-    @State var tappedItem = DSItem.placeholderItem()
+    @State var tappedItem: DSItem = .placeholderItem()
+    @State var showConfirmDelete = false
+    @State var showUnableToDelete = false
 
     @Binding var items: [DSItem]
-
     @Binding var isDaysDisplayModeDetailed: Bool
+
+    @EnvironmentObject var categoryManager: CategoryManager
+
+    var accentColor: Color { category.color.color }
 
     var body: some View {
         ZStack {
@@ -38,17 +43,53 @@ struct CategoryFilteredView: View {
                 Color(.clear)
                     .frame(height: 100)
             }
+            .padding(.top, 16)
 
             Spacer()
             addItemButton
         }
         .navigationTitle(category.name)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(content: {
+            toolbarItems
+        })
         .sheet(isPresented: $showAddItemSheet) {
             AddItemSheet(selectedCategory: category, remindersEnabled: false, items: $items)
         }
         .sheet(isPresented: $editItemSheet) {
-            EditTappedItemSheet(items: $items, tappedItem: $tappedItem, editItemSheet: $editItemSheet)
+            EditTappedItemSheet(items: $items, editItemSheet: $editItemSheet, tappedItem: $tappedItem)
+        }
+        .confirmationDialog("Delete Category", isPresented: $showConfirmDelete) {
+            Button("Delete", role: .destructive) {
+                withAnimation {
+                    categoryManager.deleteCategory(category: category)
+                }
+            }
+        } message: {
+            Text("Are you sure you want to delete this category?")
+        }
+        .alert("Delete Category", isPresented: $showUnableToDelete) {} message: {
+            Text("Can't delete category. Category contains existing events.")
+        }
+    }
+
+    var toolbarItems: some ToolbarContent {
+        Group {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    if categoryManager.isCategoryEmpty(category: category) {
+                        showConfirmDelete = true
+                    } else {
+                        showUnableToDelete = true
+                    }
+                } label: {
+                    Image(systemName: "trash")
+                        .foregroundColor(colorScheme == .dark ? .primary : accentColor)
+                        .imageScale(.large)
+                        .accessibilityLabel("Delete Category")
+                        .font(.title2)
+                }
+            }
         }
     }
 
@@ -56,7 +97,7 @@ struct CategoryFilteredView: View {
     var background: some View {
         if colorScheme == .dark {
             LinearGradient(
-                gradient: .init(colors: [category.color.opacity(0.4).darker(by: 0.4), category.color.opacity(0.2).darker(by: 0.4)]),
+                gradient: .init(colors: [category.color.color.opacity(0.4).darker(by: 0.4), category.color.color.opacity(0.2).darker(by: 0.4)]),
                 startPoint: .init(x: 1, y: 0),
                 endPoint: .init(x: 0.0001, y: 0)
             )
@@ -64,7 +105,7 @@ struct CategoryFilteredView: View {
 
         } else {
             LinearGradient(
-                gradient: .init(colors: [category.color.opacity(0.1), category.color.opacity(0.2)]),
+                gradient: .init(colors: [category.color.color.opacity(0.1), category.color.color.opacity(0.2)]),
                 startPoint: .init(x: 1, y: 0),
                 endPoint: .init(x: 0.0001, y: 0)
             )
@@ -85,12 +126,12 @@ struct CategoryFilteredView: View {
                 }
                 .padding()
                 .background(LinearGradient(
-                    gradient: .init(colors: [category.color.opacity(0.8), category.color]),
+                    gradient: .init(colors: [category.color.color.opacity(0.8), category.color.color]),
                     startPoint: .init(x: 0.0, y: 0.5),
                     endPoint: .init(x: 0, y: 1)
                 ))
                 .clipShape(Capsule())
-                .shadow(color: items.filter { $0.category.color == category.color }.count < 5 ? category.color : .white, radius: 10, x: 0, y: 5)
+                .shadow(color: items.filter { $0.category.color.color == category.color.color }.count < 5 ? category.color.color : .white, radius: 10, x: 0, y: 5)
             }
         }
     }
@@ -98,7 +139,14 @@ struct CategoryFilteredView: View {
 
 struct CategoryFilteredView_Previews: PreviewProvider {
     static var previews: some View {
-        CategoryFilteredView(category: .work, showAddItemSheet: false, editItemSheet: false, tappedItem: DSItem.placeholderItem(), items: .constant([DSItem.placeholderItem()]), isDaysDisplayModeDetailed: .constant(false))
-            .preferredColorScheme(.dark)
+        CategoryFilteredView(
+            category: Category.placeholderCategory(),
+            showAddItemSheet: false,
+            editItemSheet: false,
+            tappedItem: DSItem.placeholderItem(),
+            items: .constant([DSItem.placeholderItem()]),
+            isDaysDisplayModeDetailed: .constant(false)
+        )
+        .preferredColorScheme(.dark)
     }
 }

--- a/DaysSince/CategoriesViews/CategoryRectangleView.swift
+++ b/DaysSince/CategoriesViews/CategoryRectangleView.swift
@@ -6,56 +6,56 @@
 //
 
 import SwiftUI
-
-struct CategoryRectangleView: View {
-//    init(category: CategoryDaysSinceItem = CategoryDaysSinceItem.health, selectedCategory: CategoryDaysSinceItem? = CategoryDaysSinceItem.hobbies) {
-//        self.category = category
-//        self.selectedCategory = selectedCategory
+//
+// struct CategoryRectangleView: View {
+////    init(category: CategoryDaysSinceItem = CategoryDaysSinceItem.health, selectedCategory: CategoryDaysSinceItem? = CategoryDaysSinceItem.hobbies) {
+////        self.category = category
+////        self.selectedCategory = selectedCategory
+////    }
+//
+//    var category: CategoryDSItem
+//
+//    var selectedCategory: CategoryDSItem?
+//
+//    var body: some View {
+//        ZStack(alignment: .leading) {
+//            backgroundColor
+//            categoryBlockContent
+//        }
+//        .clipShape(RoundedRectangle(cornerRadius: 24))
+//        .padding(.horizontal, 12)
+//        .padding(.vertical, 4)
+//        .shadow(color: selectedCategory == nil ? category.color : selectedCategory == category ? category.color : category.color.opacity(0.2), radius: 10, x: 0, y: 5)
 //    }
-
-    var category: CategoryDSItem
-
-    var selectedCategory: CategoryDSItem?
-
-    var body: some View {
-        ZStack(alignment: .leading) {
-            backgroundColor
-            categoryBlockContent
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 24))
-        .padding(.horizontal, 12)
-        .padding(.vertical, 4)
-        .shadow(color: selectedCategory == nil ? category.color : selectedCategory == category ? category.color : category.color.opacity(0.2), radius: 10, x: 0, y: 5)
-    }
-
-    var backgroundColor: some View {
-        category.color
-            .opacity(selectedCategory == nil ? 1 : selectedCategory == category ? 1 : 0.7)
-    }
-
-    var categoryBlockContent: some View {
-        VStack(alignment: .center) {
-            emoji
-            titleText
-        }
-        .foregroundColor(.white)
-        .padding()
-    }
-
-    @ViewBuilder
-    var emoji: some View {
-        Image(category.emoji)
-    }
-
-    var titleText: some View {
-        Text(category.name)
-            .font(.system(.title2, design: .rounded))
-            .bold()
-    }
-}
-
-struct CategoryRectangleView_Previews: PreviewProvider {
-    static var previews: some View {
-        CategoryRectangleView(category: .health, selectedCategory: nil)
-    }
-}
+//
+//    var backgroundColor: some View {
+//        category.color
+//            .opacity(selectedCategory == nil ? 1 : selectedCategory == category ? 1 : 0.7)
+//    }
+//
+//    var categoryBlockContent: some View {
+//        VStack(alignment: .center) {
+//            emoji
+//            titleText
+//        }
+//        .foregroundColor(.white)
+//        .padding()
+//    }
+//
+//    @ViewBuilder
+//    var emoji: some View {
+//        Image(category.emoji)
+//    }
+//
+//    var titleText: some View {
+//        Text(category.name)
+//            .font(.system(.title2, design: .rounded))
+//            .bold()
+//    }
+// }
+//
+// struct CategoryRectangleView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        CategoryRectangleView(category: .health, selectedCategory: nil)
+//    }
+// }

--- a/DaysSince/CategoryManager.swift
+++ b/DaysSince/CategoryManager.swift
@@ -1,0 +1,65 @@
+//
+//  CategoryManager.swift
+//  DaysSince
+//
+//  Created by Vicki Minerva on 11/24/23.
+//
+
+import Defaults
+import Foundation
+import SwiftUI
+
+class CategoryManager: ObservableObject {
+    @Default(.categories) var categories: [Category]
+    @AppStorage("items", store: UserDefaults(suiteName: "group.goodsnooze.dayssince")) var items: [DSItem] = []
+
+    func addCategory(name: String, emoji: String, color: CategoryColor) {
+        let newCategory = Category(name: name, emoji: emoji, color: color)
+        categories.append(newCategory)
+    }
+
+    func deleteCategory(at index: Int) {
+        guard index < categories.count else { return }
+
+        let categoryToDelete = categories[index]
+
+        if !isCategoryEmpty(category: categoryToDelete) {
+            print("Can't delete category. There are existing events in that category.")
+            return
+        }
+
+        categories.remove(at: index)
+        print("Delete category \(categoryToDelete.name)")
+    }
+
+    func deleteCategory(category: Category) {
+        if !isCategoryEmpty(category: category) {
+            print("Can't delete category. There are existing events in that category.")
+            return
+        }
+
+        guard let indexToDelete = categories.firstIndex(of: category) else { return }
+
+        categories.remove(at: indexToDelete)
+        print("Delete category \(category.name)")
+    }
+
+    func isCategoryEmpty(category: Category) -> Bool {
+        if items.contains(where: { $0.category == category }) {
+            return false
+        }
+        return true
+    }
+
+    func isCategoryEmpty(index: Int) -> Bool {
+        guard index < categories.count else { return false }
+
+        let category = categories[index]
+
+        if items.contains(where: { $0.category == category }) {
+            return false
+        }
+
+        return true
+    }
+}

--- a/DaysSince/ContentView.swift
+++ b/DaysSince/ContentView.swift
@@ -15,12 +15,14 @@ struct ContentView: View {
 
     @AppStorage("isDaysDisplayModeDetailed") var isDaysDisplayModeDetailed: Bool = false
 
+    @Default(.categories) var categories
     @Default(.mainColor) var mainColor
     @Default(.backgroundColor) var backgroundColor
 
     var body: some View {
         if hasSeenOnboarding {
-            MainScreen(items: $items, isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed)
+            MainScreen(items: $items,
+                       isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed)
         } else {
             OnboardingScreen(hasSeenOnboarding: $hasSeenOnboarding, items: $items)
         }

--- a/DaysSince/DaysSince/AddNewItem/AddItemForm.swift
+++ b/DaysSince/DaysSince/AddNewItem/AddItemForm.swift
@@ -11,15 +11,16 @@ struct AddItemForm: View {
     @Binding var items: [DSItem]
     @Binding var name: String
     @Binding var date: Date
-    @Binding var category: CategoryDSItem?
+    @Binding var category: Category?
     @Binding var remindersEnabled: Bool
+    @Binding var showCategorySheet: Bool
 
     let reminders = ["Daily", "Weekly", "Monthly"]
 
     @Binding var selectedReminder: DSItemReminders
 
     var accentColor: Color {
-        category == nil ? Color.black : category?.color as! Color
+        category?.color.color ?? Color.black
     }
 
     @FocusState.Binding var nameIsFocused: Bool
@@ -30,7 +31,7 @@ struct AddItemForm: View {
                 Form {
                     nameSection
                     dateSection
-                    newCategorySection
+                    CategoryFormSection(selectedCategory: $category, showCategorySheet: $showCategorySheet)
                     reminderSection
                 }
                 .scrollDismissesKeyboard(.immediately) // Only available for iOS 16+
@@ -46,11 +47,11 @@ struct AddItemForm: View {
             Form {
                 nameSection
                 dateSection
-                newCategorySection
+                CategoryFormSection(selectedCategory: $category, showCategorySheet: $showCategorySheet)
                 reminderSection
             }
             // Focus name field when the sheet is opened.
-            // On older iOS versions it didn't work if you immediatly focused it so it had to have a slight delay.
+            // On older iOS versions it didn't work if you immediatly focused a field, so it had to have a slight delay.
             .onAppear {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
                     nameIsFocused = true
@@ -73,7 +74,7 @@ struct AddItemForm: View {
         Section {
             DatePicker("Event Date", selection: $date, in: ...Date.now, displayedComponents: .date)
                 .datePickerStyle(.graphical)
-                .accentColor(self.category != nil ? self.category!.color : Color.blue)
+                .accentColor(accentColor)
         } header: {
             Text("Date")
         }
@@ -82,7 +83,7 @@ struct AddItemForm: View {
     var reminderSection: some View {
         Section {
             Toggle("Reminders", isOn: $remindersEnabled.animation())
-                .tint(self.category != nil ? self.category!.color : Color.green)
+                .tint(accentColor)
             // Select type of reminder
             if remindersEnabled {
                 Picker("Remind me", selection: $selectedReminder) {
@@ -94,34 +95,6 @@ struct AddItemForm: View {
             }
         } header: {
             Text("Reminders")
-        }
-    }
-
-    var newCategorySection: some View {
-        Section {
-            ForEach(CategoryDSItem.allCases) { category in
-                Button {
-                    self.category = category
-                } label: {
-                    HStack {
-                        Image(systemName: category.sfSymbolName)
-                            .foregroundColor(self.category == category ? self.category!.color : .primary)
-                            .frame(width: 40)
-
-                        Text(category.name)
-                        Spacer()
-
-                        if self.category == category {
-                            Image(systemName: "checkmark.circle.fill")
-                                .imageScale(.large)
-                                .foregroundColor(self.category!.color)
-                        }
-                    }
-                }
-                .foregroundColor(.primary)
-            }
-        } header: {
-            Text("Category")
         }
     }
 }
@@ -140,16 +113,15 @@ struct Background<Content: View>: View {
     }
 }
 
-// TODO: fix the preview
-// struct AddItemForm_Previews: PreviewProvider {
-//
-//    static var previews: some View {
-//        AddItemForm(items: .constant([]),
-//                    name: .constant(""),
-//                    date: .constant(Date.now),
-//                    category: .constant(CategoryDSItem.work),
-//                    remindersEnabled: .constant(true),
-//                    selectedReminder: .constant(DSItemReminders.daily),
-//                    nameIsFocused: .constant(false))
-//    }
-// }
+struct AddItemForm_Previews: PreviewProvider {
+    static var previews: some View {
+        AddItemForm(items: .constant([]),
+                    name: .constant(""),
+                    date: .constant(Date.now),
+                    category: .constant(Category.placeholderCategory()),
+                    remindersEnabled: .constant(true),
+                    showCategorySheet: .constant(false),
+                    selectedReminder: .constant(DSItemReminders.daily),
+                    nameIsFocused: FocusState<Bool>().projectedValue)
+    }
+}

--- a/DaysSince/DaysSince/EditExistingItem/EditTappedItemForm.swift
+++ b/DaysSince/DaysSince/EditExistingItem/EditTappedItemForm.swift
@@ -13,11 +13,12 @@ struct EditTappedItemForm: View {
     @EnvironmentObject var notificationManager: NotificationManager
 
     @Binding var items: [DSItem]
-
-    @Binding var tappedItem: DSItem
     @Binding var editItemSheet: Bool
+    @Binding var tappedItem: DSItem
+    @Binding var showCategorySheet: Bool
 
-    var category: CategoryDSItem = .hobbies
+    var category: Category { tappedItem.category }
+    var accentColor: Color { category.color.color }
 
     @FocusState.Binding var nameIsFocused: Bool
     @State var showConfirmDelete = false
@@ -27,7 +28,10 @@ struct EditTappedItemForm: View {
             Form {
                 nameSection
                 dateSection
-                newCategorySection
+                CategoryFormSection(selectedCategory: Binding(
+                    get: { tappedItem.category },
+                    set: { tappedItem.category = $0! }
+                ), showCategorySheet: $showCategorySheet)
                 reminderSection
                 deleteButtonSection
             }
@@ -44,7 +48,10 @@ struct EditTappedItemForm: View {
             Form {
                 nameSection
                 dateSection
-                newCategorySection
+                CategoryFormSection(selectedCategory: Binding(
+                    get: { tappedItem.category },
+                    set: { tappedItem.category = $0! }
+                ), showCategorySheet: $showCategorySheet)
                 reminderSection
                 deleteButtonSection
             }
@@ -73,7 +80,7 @@ struct EditTappedItemForm: View {
     var reminderSection: some View {
         Section {
             Toggle("Reminders", isOn: $tappedItem.remindersEnabled.animation())
-                .tint(tappedItem.category.color)
+                .tint(accentColor)
 //                .onChange(of: tappedItem.remindersEnabled) { remindersEnabled in
 //
 //                    if remindersEnabled {
@@ -117,38 +124,9 @@ struct EditTappedItemForm: View {
         Section {
             DatePicker("Event Date", selection: $tappedItem.dateLastDone, in: ...Date.now, displayedComponents: .date)
                 .datePickerStyle(.graphical)
-                .accentColor(tappedItem.category.color)
+                .accentColor(accentColor)
         } header: {
             Text("Date")
-        }
-    }
-
-    var newCategorySection: some View {
-        Section {
-            ForEach(CategoryDSItem.allCases) { category in
-                Button {
-                    tappedItem.category = category
-                } label: {
-                    HStack {
-                        Image(systemName: category.sfSymbolName)
-                            .foregroundColor(tappedItem.category == category ? tappedItem.category.color : .primary)
-                            .frame(width: 40)
-
-                        Text(category.name)
-
-                        Spacer()
-
-                        if tappedItem.category == category {
-                            Image(systemName: "checkmark.circle.fill")
-                                .imageScale(.large)
-                                .foregroundColor(tappedItem.category.color)
-                        }
-                    }
-                }
-                .foregroundColor(.primary)
-            }
-        } header: {
-            Text("Category")
         }
     }
 
@@ -192,8 +170,12 @@ struct EditTappedItemForm: View {
     }
 }
 
-// struct EditTappedItemForm_Previews: PreviewProvider {
-//    static var previews: some View {
-//        EditTappedItemForm(items: .constant([]), completedItems: .constant([]), favoriteItems: .constant([]), tappedItem: .constant(DaysSinceItem.placeholderItem()), editItemSheet: .constant(true), nameIsFocused: .constant(false))
-//    }
-// }
+struct EditTappedItemForm_Previews: PreviewProvider {
+    static var previews: some View {
+        EditTappedItemForm(items: .constant([]),
+                           editItemSheet: .constant(true),
+                           tappedItem: .constant(DSItem.placeholderItem()),
+                           showCategorySheet: .constant(false),
+                           nameIsFocused: FocusState<Bool>().projectedValue)
+    }
+}

--- a/DaysSince/DaysSince/MainScreen/MainScreen.swift
+++ b/DaysSince/DaysSince/MainScreen/MainScreen.swift
@@ -9,21 +9,23 @@ import Defaults
 import SwiftUI
 
 struct MainScreen: View {
+    @Default(.categories) var categories
     @Default(.mainColor) var mainColor
     @Default(.backgroundColor) var backgroundColor
 
     @Environment(\.colorScheme) var colorScheme
 
+    @EnvironmentObject var notificationManager: NotificationManager
+    @EnvironmentObject var categoryManager: CategoryManager
+
     @State var showAddItemSheet = false
     @State var showSettings = false
     @State var editItemSheet = false
-    @State var tappedItem = DSItem.placeholderItem()
+    @State var tappedItem: DSItem = .placeholderItem()
     @State var showThemeSheet = false
 
     @Binding var items: [DSItem]
     @Binding var isDaysDisplayModeDetailed: Bool
-
-    @EnvironmentObject var notificationManager: NotificationManager
 
     var body: some View {
         NavigationView {
@@ -72,8 +74,8 @@ struct MainScreen: View {
                 .sheet(isPresented: $editItemSheet) {
                     EditTappedItemSheet(
                         items: $items,
-                        tappedItem: $tappedItem,
-                        editItemSheet: $editItemSheet
+                        editItemSheet: $editItemSheet,
+                        tappedItem: $tappedItem
                     )
                 }
 
@@ -84,7 +86,6 @@ struct MainScreen: View {
             }
             .navigationTitle("Events")
             .navigationBarTitleDisplayMode(.inline)
-
             .toolbar(content: {
                 toolbarItems
             })
@@ -165,7 +166,10 @@ struct MainScreen: View {
 
 struct MainScreen_Previews: PreviewProvider {
     static var previews: some View {
-        MainScreen(items: .constant([.placeholderItem()]), isDaysDisplayModeDetailed: .constant(false))
-            .preferredColorScheme(.light)
+        MainScreen(
+            items: .constant([.placeholderItem()]),
+            isDaysDisplayModeDetailed: .constant(false)
+        )
+        .preferredColorScheme(.light)
     }
 }

--- a/DaysSince/DaysSince/MainScreen/Views/BottomSection/BottomSection.swift
+++ b/DaysSince/DaysSince/MainScreen/Views/BottomSection/BottomSection.swift
@@ -5,9 +5,12 @@
 //  Created by Vicki Minerva on 5/23/22.
 //
 
+import Defaults
 import SwiftUI
 
 struct BottomSection: View {
+    @Default(.categories) var categories
+
     @Binding var items: [DSItem]
 
     @Binding var editItemSheet: Bool
@@ -31,6 +34,9 @@ struct BottomSection: View {
 
 struct BottomSection_Previews: PreviewProvider {
     static var previews: some View {
-        BottomSection(items: .constant([.placeholderItem()]), editItemSheet: .constant(false), tappedItem: .constant(DSItem.placeholderItem()), isDaysDisplayModeDetailed: .constant(false))
+        BottomSection(items: .constant([.placeholderItem()]),
+                      editItemSheet: .constant(false),
+                      tappedItem: .constant(DSItem.placeholderItem()),
+                      isDaysDisplayModeDetailed: .constant(false))
     }
 }

--- a/DaysSince/DaysSince/MainScreen/Views/BottomSection/DSItemView.swift
+++ b/DaysSince/DaysSince/MainScreen/Views/BottomSection/DSItemView.swift
@@ -32,7 +32,7 @@ struct DSItemView: View {
         .overlay(
             RoundedRectangle(cornerRadius: 20)
                 .stroke(
-                    colorScheme == .dark ? item.category.color.darker() : item.category.color,
+                    colorScheme == .dark ? item.category.color.color.darker() : item.category.color.color,
                     lineWidth: 3
                 )
         )
@@ -48,7 +48,7 @@ struct DSItemView: View {
         Text(item.name)
             .font(.system(.title2, design: .rounded))
             .bold()
-            .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color)
+            .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
     }
 
     @ViewBuilder
@@ -70,11 +70,11 @@ struct DSItemView: View {
                         Text("\(years)")
                             .font(.system(.title3, design: .rounded))
                             .bold()
-                            .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color)
+                            .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
 
                         Text(years > 1 ? "years" : "year")
                             .font(.system(.caption, design: .rounded))
-                            .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color)
+                            .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
                     }
                 }
 
@@ -83,11 +83,11 @@ struct DSItemView: View {
                         Text("\(months)")
                             .font(.system(.title3, design: .rounded))
                             .bold()
-                            .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color)
+                            .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
 
                         Text(months > 1 ? "months" : "month")
                             .font(.system(.caption, design: .rounded))
-                            .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color)
+                            .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
                     }
                 }
 
@@ -95,11 +95,11 @@ struct DSItemView: View {
                     Text("\(days)")
                         .font(.system(months > 0 || years > 0 ? .title3 : .title2, design: .rounded))
                         .bold()
-                        .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color)
+                        .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
 
                     Text(days > 1 ? "days" : "day")
                         .font(.system(months > 0 || years > 0 ? .caption : .body, design: .rounded))
-                        .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color)
+                        .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
                 }
             }
             .frame(minWidth: 0)
@@ -110,11 +110,11 @@ struct DSItemView: View {
                 Text("\(item.daysAgo)")
                     .font(.system(.title2, design: .rounded))
                     .bold()
-                    .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color)
+                    .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
 
                 Text(item.daysAgo > 1 ? "days" : "day")
                     .font(.system(.body, design: .rounded))
-                    .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color)
+                    .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
             }
             .frame(minWidth: 0)
         }
@@ -123,9 +123,9 @@ struct DSItemView: View {
     @ViewBuilder
     var backgroundColor: some View {
         if colorScheme == .dark {
-            item.category.color.lighter(by: 0.04)
+            item.category.color.color.lighter(by: 0.04)
         } else if colored {
-            item.category.color
+            item.category.color.color
         } else {
             Color.white
         }

--- a/DaysSince/DaysSince/MainScreen/Views/BottomSection/ItemLists/DSItemListView.swift
+++ b/DaysSince/DaysSince/MainScreen/Views/BottomSection/ItemLists/DSItemListView.swift
@@ -14,7 +14,7 @@ struct DSItemListView: View {
     @Binding var isDaysDisplayModeDetailed: Bool
 
     var isCategoryView: Bool = false
-    var category: CategoryDSItem = .work
+    var category: Category?
 
     var body: some View {
         if isCategoryView {
@@ -54,6 +54,6 @@ struct DSItemListView: View {
 
 struct NormalItemsList_Previews: PreviewProvider {
     static var previews: some View {
-        DSItemListView(items: .constant([]), editItemSheet: .constant(false), tappedItem: .constant(.placeholderItem()), isDaysDisplayModeDetailed: .constant(false))
+        DSItemListView(items: .constant([]), editItemSheet: .constant(false), tappedItem: .constant(.placeholderItem()), isDaysDisplayModeDetailed: .constant(false), category: Category.placeholderCategory())
     }
 }

--- a/DaysSince/DaysSince/MainScreen/Views/MainBackgroundView.swift
+++ b/DaysSince/DaysSince/MainScreen/Views/MainBackgroundView.swift
@@ -28,8 +28,8 @@ struct MainBackgroundView: View {
     }
 }
 
-// struct MainBackgroundView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        MainBackgroundView(mainColor:Binding<Color.workColor>)
-//    }
-// }
+struct MainBackgroundView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainBackgroundView()
+    }
+}

--- a/DaysSince/DaysSince/MainScreen/Views/TopSection/MenuBlockView.swift
+++ b/DaysSince/DaysSince/MainScreen/Views/TopSection/MenuBlockView.swift
@@ -10,9 +10,11 @@ import SwiftUI
 struct MenuBlockView: View {
     @Environment(\.colorScheme) var colorScheme
 
-    let category: CategoryDSItem
+    let category: Category
 
     @Binding var items: [DSItem]
+
+    var accentColor: Color { category.color.color }
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -21,7 +23,7 @@ struct MenuBlockView: View {
         }
         .foregroundColor(.white)
         .clipShape(RoundedRectangle(cornerRadius: 20))
-        .shadow(color: category.color.opacity(0.4), radius: 5, x: 0, y: 5)
+        .shadow(color: accentColor.opacity(0.4), radius: 5, x: 0, y: 5)
     }
 
     @ViewBuilder
@@ -32,8 +34,8 @@ struct MenuBlockView: View {
                     LinearGradient(
                         gradient: .init(
                             colors: [
-                                category.color.opacity(0.84).darker(),
-                                category.color.darker(),
+                                accentColor.opacity(0.84).darker(),
+                                accentColor.darker(),
                             ]
                         ),
                         startPoint: .init(x: 0.0, y: 0),
@@ -46,8 +48,8 @@ struct MenuBlockView: View {
                     LinearGradient(
                         gradient: .init(
                             colors: [
-                                category.color.opacity(0.7),
-                                category.color,
+                                accentColor.opacity(0.7),
+                                accentColor,
                             ]
                         ),
                         startPoint: .init(x: 0.0, y: 0),
@@ -68,7 +70,7 @@ struct MenuBlockView: View {
 
     @ViewBuilder
     var emoji: some View {
-        Image(systemName: category.sfSymbolName)
+        Image(systemName: category.emoji)
             .imageScale(.large)
             .foregroundColor(.white)
     }
@@ -91,7 +93,7 @@ struct MenuBlockView: View {
 
 struct MenuBlockView_Previews: PreviewProvider {
     static var previews: some View {
-        MenuBlockView(category: .work, items: .constant([]))
+        MenuBlockView(category: Category.placeholderCategory(), items: .constant([]))
             .preferredColorScheme(.dark)
     }
 }

--- a/DaysSince/DaysSince/MainScreen/Views/TopSection/TopSection.swift
+++ b/DaysSince/DaysSince/MainScreen/Views/TopSection/TopSection.swift
@@ -5,6 +5,7 @@
 //  Created by Vicki Minerva on 5/23/22.
 //
 
+import Defaults
 import SwiftUI
 
 /**
@@ -12,77 +13,85 @@ import SwiftUI
  By clicking on any of the categories it will lead you to a filtered view with events only from that category.
  */
 struct TopSection: View {
-    @Binding var items: [DSItem]
+    @Default(.categories) var categories
 
+    @Binding var items: [DSItem]
     @Binding var isDaysDisplayModeDetailed: Bool
 
     var body: some View {
-        HStack {
-            VStack {
-                NavigationLink(
-                    destination: CategoryFilteredView(
-                        category: CategoryDSItem.work,
-                        showAddItemSheet: false,
-                        editItemSheet: false,
-                        items: $items,
-                        isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed
-                    )
-                ) {
-                    MenuBlockView(
-                        category: .work,
-                        items: $items
-                    )
-                }
-
-                NavigationLink(
-                    destination: CategoryFilteredView(
-                        category: CategoryDSItem.life,
-                        showAddItemSheet: false,
-                        editItemSheet: false,
-                        items: $items,
-                        isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed
-                    )
-                ) {
-                    MenuBlockView(
-                        category: .life,
-                        items: $items
-                    )
+        ScrollView(.horizontal) {
+            LazyHStack {
+                ForEach(categories, id: \.id) { category in
+                    NavigationLink(
+                        destination: CategoryFilteredView(
+                            category: category,
+                            showAddItemSheet: false,
+                            editItemSheet: false,
+                            items: $items,
+                            isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed
+                        )
+                    ) {
+                        MenuBlockView(
+                            category: category,
+                            items: $items
+                        )
+                        .aspectRatio(1.0, contentMode: .fit) // Maintain square aspect ratio
+                        .frame(minWidth: 0, maxWidth: .infinity)
+                    }
                 }
             }
-
-            VStack {
-                NavigationLink(
-                    destination: CategoryFilteredView(
-                        category: CategoryDSItem.health,
-                        showAddItemSheet: false,
-                        editItemSheet: false,
-                        items: $items,
-                        isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed
-                    )
-                ) {
-                    MenuBlockView(
-                        category: .health,
-                        items: $items
-                    )
-                }
-
-                NavigationLink(
-                    destination: CategoryFilteredView(
-                        category: CategoryDSItem.hobbies,
-                        showAddItemSheet: false,
-                        editItemSheet: false,
-                        items: $items,
-                        isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed
-                    )
-                ) {
-                    MenuBlockView(
-                        category: .hobbies,
-                        items: $items
-                    )
-                }
-            }
+            .padding(.horizontal, 16) // Adjust horizontal padding as needed
+            .padding(.vertical, 16) // Adjust vertical padding as needed
         }
-        .padding(.horizontal)
+        .padding(.leading, 16)
+//
+//
+//                NavigationLink(
+//                    destination: CategoryFilteredView(
+//                        category: CategoryDSItem.life,
+//                        showAddItemSheet: false,
+//                        editItemSheet: false,
+//                        items: $items,
+//                        isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed
+//                    )
+//                ) {
+//                    MenuBlockView(
+//                        category: .life,
+//                        items: $items
+//                    )
+//                }
+//            }
+//
+//            VStack {
+//                NavigationLink(
+//                    destination: CategoryFilteredView(
+//                        category: CategoryDSItem.health,
+//                        showAddItemSheet: false,
+//                        editItemSheet: false,
+//                        items: $items,
+//                        isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed
+//                    )
+//                ) {
+//                    MenuBlockView(
+//                        category: .health,
+//                        items: $items
+//                    )
+//                }
+//
+//                NavigationLink(
+//                    destination: CategoryFilteredView(
+//                        category: CategoryDSItem.hobbies,
+//                        showAddItemSheet: false,
+//                        editItemSheet: false,
+//                        items: $items,
+//                        isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed
+//                    )
+//                ) {
+//                    MenuBlockView(
+//                        category: .hobbies,
+//                        items: $items
+//                    )
+//                }
     }
 }
 

--- a/DaysSince/DaysSince/Model/CategoryDSItem.swift
+++ b/DaysSince/DaysSince/Model/CategoryDSItem.swift
@@ -8,8 +8,8 @@
 import Foundation
 import SwiftUI
 
-enum CategoryDSItem: Codable, Identifiable, Equatable, CaseIterable, Hashable {
-    static var allCases: [CategoryDSItem] = [
+enum CategoryDSIte: Codable, Identifiable, Equatable, CaseIterable, Hashable {
+    static var allCases: [CategoryDSIte] = [
         .work, .life, .hobbies, .health,
     ]
 

--- a/DaysSince/DaysSinceApp.swift
+++ b/DaysSince/DaysSinceApp.swift
@@ -12,6 +12,7 @@ import WidgetKit
 @main
 struct DaysSinceApp: App {
     @StateObject var notificationManager = NotificationManager()
+    @StateObject var categoryManager = CategoryManager()
 
     @Environment(\.scenePhase) var scenePhase
 
@@ -19,6 +20,7 @@ struct DaysSinceApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(notificationManager)
+                .environmentObject(categoryManager)
                 .onChange(of: self.scenePhase) {
                     switch $0 {
                     case .background:

--- a/DaysSince/EditItemViews/EditTappedItemSheet.swift
+++ b/DaysSince/EditItemViews/EditTappedItemSheet.swift
@@ -11,25 +11,38 @@ struct EditTappedItemSheet: View {
     @EnvironmentObject var notificationManager: NotificationManager
 
     @Binding var items: [DSItem]
-
-    @Binding var tappedItem: DSItem
     @Binding var editItemSheet: Bool
+    @Binding var tappedItem: DSItem
 
     @Environment(\.dismiss) var dismiss
 
     @FocusState private var nameIsFocused: Bool
+    @State var showCategorySheet = false
 
     var body: some View {
         NavigationView {
             ZStack {
-                EditTappedItemForm(items: $items, tappedItem: $tappedItem, editItemSheet: $editItemSheet, nameIsFocused: $nameIsFocused)
-                    .ignoresSafeArea(.keyboard, edges: .bottom)
-                    .navigationTitle("Edit Event")
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbar(content: {
-                        toolbarItems
-                    })
+                EditTappedItemForm(
+                    items: $items,
+                    editItemSheet: $editItemSheet,
+                    tappedItem: $tappedItem,
+                    showCategorySheet: $showCategorySheet,
+                    nameIsFocused: $nameIsFocused
+                )
+                .ignoresSafeArea(.keyboard, edges: .bottom)
+                .navigationTitle("Edit Event")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar(content: {
+                    toolbarItems
+                })
             }
+        }
+        .sheet(isPresented: $showCategorySheet) {
+            AddCategorySheet()
+                .presentationDragIndicator(.hidden)
+                .presentationDetents([.medium])
+                .presentationCornerRadius(44)
+                .onDisappear { showCategorySheet = false }
         }
     }
 
@@ -42,7 +55,7 @@ struct EditTappedItemSheet: View {
                     Image(systemName: "chevron.down.circle.fill")
                 }
                 .font(.title2)
-                .foregroundColor(tappedItem.category.color)
+                .foregroundColor(tappedItem.category.color.color)
             }
 
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -81,7 +94,7 @@ struct EditTappedItemSheet: View {
                 } label: {
                     Text("Save")
                 }
-                .foregroundColor(tappedItem.name.isEmpty ? Color.gray : tappedItem.category.color)
+                .foregroundColor(tappedItem.name.isEmpty ? Color.gray : tappedItem.category.color.color)
                 .disabled(tappedItem.name.isEmpty)
             }
 
@@ -96,7 +109,7 @@ struct EditTappedItemSheet: View {
                     } label: {
                         Text("Done")
                     }
-                    .foregroundColor(tappedItem.category.color)
+                    .foregroundColor(tappedItem.category.color.color)
                 }
             }
         }
@@ -116,6 +129,8 @@ struct EditTappedItemSheet: View {
 
 struct EditTappedItemSheet_Previews: PreviewProvider {
     static var previews: some View {
-        EditTappedItemSheet(items: .constant([]), tappedItem: .constant(DSItem.placeholderItem()), editItemSheet: .constant(false))
+        EditTappedItemSheet(items: .constant([]),
+                            editItemSheet: .constant(false),
+                            tappedItem: .constant(DSItem.placeholderItem()))
     }
 }

--- a/DaysSince/Extensions/Defaults+Extension+Colors.swift
+++ b/DaysSince/Extensions/Defaults+Extension+Colors.swift
@@ -12,4 +12,9 @@ import SwiftUI
 extension Defaults.Keys {
     static let mainColor = Key<Color>("mainColor", default: Color.workColor)
     static let backgroundColor = Key<Color>("backgroundColor", default: Color.backgroundColor)
+    static let categories = Key<[Category]>("categories", default: [
+        Category(name: "Work", emoji: "lightbulb", color: .work),
+        Category(name: "Life", emoji: "leaf", color: .life),
+        Category(name: "Hobby", emoji: "gamecontroller", color: .hobbies),
+        Category(name: "Health", emoji: "heart.text.square", color: .health)])
 }

--- a/DaysSince/Model/Category.swift
+++ b/DaysSince/Model/Category.swift
@@ -1,0 +1,28 @@
+//
+//  Category.swift
+//  DaysSince
+//
+//  Created by Vicki Minerva on 11/22/23.
+//
+
+import Defaults
+import Foundation
+import SwiftUI
+
+struct Category: Identifiable, Codable, Equatable, Defaults.Serializable {
+    let id: UUID
+    let name: String
+    let emoji: String
+    let color: CategoryColor
+
+    init(id: UUID = UUID(), name: String, emoji: String, color: CategoryColor) {
+        self.id = id
+        self.name = name
+        self.emoji = emoji
+        self.color = color
+    }
+
+    static func placeholderCategory() -> Category {
+        return Category(name: "Placeholder", emoji: "placeholder", color: .work)
+    }
+}

--- a/DaysSince/Model/CategoryColor.swift
+++ b/DaysSince/Model/CategoryColor.swift
@@ -1,0 +1,71 @@
+//
+//  CategoryColor.swift
+//  DaysSince
+//
+//  Created by Vicki Minerva on 11/22/23.
+//
+
+import Foundation
+import SwiftUI
+
+enum CategoryColor: Codable, Identifiable, Equatable, CaseIterable, Hashable {
+    static var allCases: [CategoryColor] = [
+        .work, .life, .hobbies, .health, .marioBlue, .zeldaYellow, .animalCrossingsGreen, .marioRed, .animalCrossingsBrown,
+    ]
+
+    case work
+    case life
+    case health
+    case hobbies
+    case marioBlue
+    case zeldaYellow
+    case animalCrossingsGreen
+    case marioRed
+    case animalCrossingsBrown
+
+    var id: String {
+        switch self {
+        case .work:
+            return "Work"
+        case .life:
+            return "Life"
+        case .health:
+            return "Health"
+        case .hobbies:
+            return "Hobby"
+        case .marioBlue:
+            return "MarioBlue"
+        case .zeldaYellow:
+            return "ZeldaYellow"
+        case .animalCrossingsGreen:
+            return "AnimalCrossingsGreen"
+        case .marioRed:
+            return "MarioRed"
+        case .animalCrossingsBrown:
+            return "AnimalCrossingsBrown"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .work:
+            return Color.workColor
+        case .life:
+            return Color.lifeColor
+        case .health:
+            return Color.healthColor
+        case .hobbies:
+            return Color.hobbiesColor
+        case .marioBlue:
+            return Color.marioBlue
+        case .zeldaYellow:
+            return Color.zeldaYellow
+        case .animalCrossingsGreen:
+            return Color.animalCrossingsGreen
+        case .marioRed:
+            return Color.marioRed
+        case .animalCrossingsBrown:
+            return Color.animalCrossingsBrown
+        }
+    }
+}

--- a/DaysSince/Model/DSItem.swift
+++ b/DaysSince/Model/DSItem.swift
@@ -16,7 +16,7 @@ struct DSItem: Identifiable, Codable {
     var name: String
 
     /// Category of the item.
-    var category = CategoryDSItem.work
+    var category: Category
 
     /// Day last done.
     var dateLastDone: Date
@@ -33,7 +33,7 @@ struct DSItem: Identifiable, Codable {
 
     /// The emoji of the item.
     var emoji: String {
-        return category.sfSymbolName
+        return category.emoji
     }
 
     /// The ID of the repeating notification reminder.
@@ -51,6 +51,7 @@ struct DSItem: Identifiable, Codable {
     }
 
     static func placeholderItem() -> DSItem {
-        return DSItem(id: UUID(), name: "Placeholder", category: CategoryDSItem.hobbies, dateLastDone: Date.now, remindersEnabled: false)
+        let category = Category.placeholderCategory()
+        return DSItem(id: UUID(), name: "Placeholder", category: category, dateLastDone: Date.now, remindersEnabled: false)
     }
 }

--- a/DaysSince/Onboarding/Pages/Introduction.swift
+++ b/DaysSince/Onboarding/Pages/Introduction.swift
@@ -25,7 +25,7 @@ struct Introduction: View {
     @State var colors = [
         Color.workColor,
         Color.lifeColor,
-        Color.hobbiesColor
+        Color.hobbiesColor,
     ]
 
     @State var currentIndex: Int = 2

--- a/Widget/Widget.swift
+++ b/Widget/Widget.swift
@@ -5,6 +5,7 @@
 //  Created by Jordi Bruin on 27/06/2022.
 //
 
+import Defaults
 import SwiftUI
 import WidgetKit
 
@@ -144,7 +145,7 @@ struct WidgetContent: TimelineEntry {
         date = item.dateLastDone
         name = item.name
         id = item.id
-        color = item.category.color
+        color = item.category.color.color
 
         let daysSince = Calendar.current.numberOfDaysBetween(item.dateLastDone, and: Date.now)
         daysNumber = daysSince

--- a/WidgetIntents/IntentHandler.swift
+++ b/WidgetIntents/IntentHandler.swift
@@ -5,6 +5,7 @@
 //  Created by Jordi Bruin on 27/06/2022.
 //
 
+import Defaults
 import Intents
 import SwiftUI
 


### PR DESCRIPTION
Users are able to add new categores and to delete existing ones. Adding a new category can be done through the add item or edit item forms. The logic for the categories is abstracted in a separate view. Users can choose a name, emoji and color of the new category. The emojis and colors can be chosen from several default options. 

To delete a category a user can tap on the category block and then on the trash can. The user will have to either confirm the deleation or if that's not possible an alert shows up indicating that it's not possible to delete the category. The category is not deletable when there are existing events that belong to it. 