### PR TITLE
Widgets show detailed time

### DIFF
--- a/DaysSince/ContentView.swift
+++ b/DaysSince/ContentView.swift
@@ -13,11 +13,11 @@ struct ContentView: View {
     @AppStorage("hasSeenOnboarding") var hasSeenOnboarding: Bool = false
 
     @AppStorage("items", store: UserDefaults(suiteName: "group.goodsnooze.dayssince")) var items: [DSItem] = []
-    
+
     @AppStorage("items", store: UserDefaults(suiteName: "group.goodsnooze.dayssince")) var oldItems: [oldDSItem] = []
 
-    @AppStorage("isDaysDisplayModeDetailed") var isDaysDisplayModeDetailed: Bool = false
-    
+    @AppStorage("isDaysDisplayModeDetailed", store: UserDefaults(suiteName: "group.goodsnooze.dayssince")) var isDaysDisplayModeDetailed: Bool = true
+
     @AppStorage("migratedFromOld") var migratedFromOld: Bool = false
 
     @Default(.categories) var categories
@@ -34,25 +34,25 @@ struct ContentView: View {
         if hasSeenOnboarding {
             MainScreen(items: $items,
                        isDaysDisplayModeDetailed: $isDaysDisplayModeDetailed)
-            .onAppear {
-                if !migratedFromOld {
-                    if !oldItems.isEmpty {
-                        let newItems = oldItems.map { oldItem in
-                            return DSItem(
-                                id: oldItem.id,
-                                name: oldItem.name,
-                                category: Category.placeholderCategory(),
-                                dateLastDone: oldItem.dateLastDone,
-                                remindersEnabled: oldItem.remindersEnabled,
-                                reminder: oldItem.reminder,
-                                reminderNotificationID: oldItem.reminderNotificationID
-                            )
+                .onAppear {
+                    if !migratedFromOld {
+                        if !oldItems.isEmpty {
+                            let newItems = oldItems.map { oldItem in
+                                DSItem(
+                                    id: oldItem.id,
+                                    name: oldItem.name,
+                                    category: Category.placeholderCategory(),
+                                    dateLastDone: oldItem.dateLastDone,
+                                    remindersEnabled: oldItem.remindersEnabled,
+                                    reminder: oldItem.reminder,
+                                    reminderNotificationID: oldItem.reminderNotificationID
+                                )
+                            }
+                            items = items + newItems
+                            migratedFromOld = true
                         }
-                        items = items + newItems
-                        migratedFromOld = true
                     }
                 }
-            }
         } else {
             OnboardingScreen(hasSeenOnboarding: $hasSeenOnboarding, items: $items)
         }

--- a/DaysSince/DaysSince/MainScreen/Views/BottomSection/DSItemView.swift
+++ b/DaysSince/DaysSince/MainScreen/Views/BottomSection/DSItemView.swift
@@ -72,7 +72,7 @@ struct DSItemView: View {
                             .bold()
                             .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
 
-                        Text(years > 1 ? "years" : "year")
+                        Text(years == 1 ? "year" : "years")
                             .font(.system(.caption, design: .rounded))
                             .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
                     }
@@ -85,7 +85,7 @@ struct DSItemView: View {
                             .bold()
                             .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
 
-                        Text(months > 1 ? "months" : "month")
+                        Text(months == 1 ? "month" : "months")
                             .font(.system(.caption, design: .rounded))
                             .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
                     }
@@ -97,7 +97,7 @@ struct DSItemView: View {
                         .bold()
                         .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
 
-                    Text(days > 1 ? "days" : "day")
+                    Text(days == 1 ? "day" : "days")
                         .font(.system(months > 0 || years > 0 ? .caption : .body, design: .rounded))
                         .foregroundColor(colored || colorScheme == .dark ? .white : item.category.color.color)
                 }

--- a/DaysSince/DaysSince/Model/CategoryDSItem.swift
+++ b/DaysSince/DaysSince/Model/CategoryDSItem.swift
@@ -34,7 +34,7 @@ enum CategoryDSIte: Codable, Identifiable, Equatable, CaseIterable, Hashable {
         }
     }
 
-var id: String {
+    var id: String {
         switch self {
         case .work:
             return "Work"

--- a/Widget/Widget.swift
+++ b/Widget/Widget.swift
@@ -63,6 +63,7 @@ struct SooseeWidget: Widget {
         }
         .configurationDisplayName(LocalizedStringKey("widget.title"))
         .description(LocalizedStringKey("widget.explanation"))
+        .contentMarginsDisabled() // iOS17 widgets force additional margin padding on your design
     }
 }
 
@@ -71,6 +72,8 @@ struct EventCardWidgetView: View {
 
     @Environment(\.widgetFamily) var family
     @Environment(\.colorScheme) var colorScheme
+
+    @AppStorage("isDaysDisplayModeDetailed", store: UserDefaults(suiteName: "group.goodsnooze.dayssince")) var isDaysDisplayModeDetailed: Bool = true
 
     @ViewBuilder
     var body: some View {
@@ -98,18 +101,70 @@ struct EventCardWidgetView: View {
             .foregroundColor(colorScheme == .dark ? .primary : event.color)
     }
 
+    @ViewBuilder
     var daysAgoText: some View {
-        VStack(alignment: .leading) {
-            Text("\(event.daysNumber)")
-                .font(.system(.title2, design: .rounded))
-                .bold()
-                .foregroundColor(colorScheme == .dark ? .primary : event.color)
+        let currentDate = Date()
+        let calendar = Calendar.current
 
-            Text("days")
-                .font(.system(.body, design: .rounded))
-                .foregroundColor(colorScheme == .dark ? .primary : event.color)
+        let dateComponents = calendar.dateComponents([.year, .month, .day], from: event.date, to: currentDate)
+
+        let years = dateComponents.year ?? 0
+        let months = dateComponents.month ?? 0
+        let days = dateComponents.day ?? 0
+
+        if isDaysDisplayModeDetailed {
+            HStack(alignment: .top, spacing: 6) {
+                if years > 0 {
+                    VStack(alignment: .center) {
+                        Text("\(years)")
+                            .font(.system(.title2, design: .rounded))
+                            .bold()
+                            .foregroundColor(colorScheme == .dark ? .primary : event.color)
+
+                        Text(years == 1 ? "year" : "years")
+                            .font(.system(years > 9 || months > 9 ? .caption : .caption, design: .rounded))
+                            .foregroundColor(colorScheme == .dark ? .primary : event.color)
+                    }
+                }
+
+                if months > 0 || years > 0 {
+                    VStack(alignment: .center) {
+                        Text("\(months)")
+                            .font(.system(.title2, design: .rounded))
+                            .bold()
+                            .foregroundColor(colorScheme == .dark ? .primary : event.color)
+
+                        Text(months == 1 ? "month" : "months")
+                            .font(.system(years > 0 ? .caption : .body, design: .rounded))
+                            .foregroundColor(colorScheme == .dark ? .primary : event.color)
+                    }
+                }
+
+                VStack(alignment: .center) {
+                    Text("\(days)")
+                        .font(.system(.title2, design: .rounded))
+                        .bold()
+                        .foregroundColor(colorScheme == .dark ? .primary : event.color)
+
+                    Text(days == 1 ? "day" : "days")
+                        .font(.system(years > 0 ? .caption : .body, design: .rounded))
+                        .foregroundColor(colorScheme == .dark ? .primary : event.color)
+                }
+            }
+            .padding(.trailing, 0)
+        } else {
+            VStack(alignment: .leading) {
+                Text("\(event.daysNumber)")
+                    .font(.system(event.daysNumber > 9999 ? .title3 : .title2, design: .rounded))
+                    .bold()
+                    .foregroundColor(colorScheme == .dark ? .primary : event.color)
+
+                Text("days")
+                    .font(.system(.body, design: .rounded))
+                    .foregroundColor(colorScheme == .dark ? .primary : event.color)
+            }
+            .frame(width: event.daysNumber > 999 ? 70 : event.daysNumber > 99 ? 50 : 40)
         }
-        .frame(width: event.daysNumber > 999 ? 70 : event.daysNumber > 99 ? 50 : 40)
     }
 
     var itemContent: some View {

--- a/Widget/Widget.swift
+++ b/Widget/Widget.swift
@@ -90,8 +90,8 @@ struct EventCardWidgetView: View {
             RoundedRectangle(cornerRadius: 23)
                 .stroke(colorScheme == .dark ? event.color.darker() : event.color, lineWidth: 6)
         )
-
         .shadow(color: Color.black.opacity(0.05), radius: 20, x: 0, y: 0)
+        .widgetBackground(Color.clear) // Widgets changed with iOS 17, need to set the background to make them work 
     }
 
     var nameText: some View {
@@ -204,5 +204,19 @@ struct WidgetContent: TimelineEntry {
 
         let daysSince = Calendar.current.numberOfDaysBetween(item.dateLastDone, and: Date.now)
         daysNumber = daysSince
+    }
+}
+
+// Widgets changed with iOS 17
+// A hot fix for this so it still works on iOS16 devices
+extension View {
+    func widgetBackground(_ backgroundView: some View) -> some View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            return containerBackground(for: .widget) {
+                backgroundView
+            }
+        } else {
+            return background(backgroundView)
+        }
     }
 }


### PR DESCRIPTION
1. Widgets now show the detailed time (not just in terms of days but also in terms of months and years)
It's based on the `isDetailedTimDisplayed` setting that already existed and is stored in @USerDefaults
2. The widget text fits any device, I tested it on both the smallest iPhone SE and on the iPhone 15 Pro
3. The widgets were broken. There was some new update with iOS 17 so I fixed that by adding an extension to the View and setting the background. 
4. The main view of the app didn't show "day(s)", "year(s), "month(s) correctly so I fixed that as well, 