### PR TITLE
Notifications

### DIFF
--- a/DaysSince/DaysSince/MainScreen/MainScreen.swift
+++ b/DaysSince/DaysSince/MainScreen/MainScreen.swift
@@ -55,7 +55,7 @@ struct MainScreen: View {
 //                        .buttonStyle(.borderedProminent)
 //
 //                        ForEach(notificationManager.pendingNotifications, id: \.self) { notification in
-//                            Text(notification.content.title)
+//                            Text("🔔 for event: \(notification.content.title)")
 //                            Text("\(notification.trigger!)")
 //                        }
 //                    }

--- a/DaysSince/NotificationManager.swift
+++ b/DaysSince/NotificationManager.swift
@@ -96,66 +96,85 @@ class NotificationManager: ObservableObject {
         var requests: [UNNotificationRequest] = []
 
         switch item.reminder {
+            
         case .daily:
-            for i in 0 ... 6 {
-                let content = UNMutableNotificationContent()
-                content.title = "\(item.name)"
-                content.body = "It's been \(item.daysAgo + i) days since \(item.name)!"
-                content.sound = UNNotificationSound.default
+            let content = UNMutableNotificationContent()
+            content.title = "\(item.name)"
+            content.body = "One more day since \(item.name)!"
+            content.sound = UNNotificationSound.default
 
-                let dateComponents = getDateComponentsFor(item: item, extraDays: Double(i))
-                let trigger = UNCalendarNotificationTrigger(
-                    dateMatching: dateComponents,
-                    repeats: false
-                )
+//                let dateComponents = getDateComponentsFor(item: item, extraDays: Double(i))
+            let calendar = Calendar.current
+            var dateComponents = DateComponents(calendar: calendar, timeZone: TimeZone.current)
+            dateComponents.hour = 10
+            dateComponents.minute = 0
+            
+            let trigger = UNCalendarNotificationTrigger(
+                dateMatching: dateComponents,
+                repeats: true
+            )
 
-                let request = UNNotificationRequest(
-                    identifier: "\(item.reminderNotificationID)\(i)",
-                    content: content,
-                    trigger: trigger
-                )
-                requests.append(request)
-            }
+            let request = UNNotificationRequest(
+                identifier: "\(item.reminderNotificationID)",
+                content: content,
+                trigger: trigger
+            )
+            requests.append(request)
+
         case .weekly:
-            for i in 0 ... 3 {
-                let content = UNMutableNotificationContent()
-                content.title = "\(item.name)"
-                content.body = "It's been \(item.daysAgo + (i * 7)) days since \(item.name)!"
-                content.sound = UNNotificationSound.default
+            let content = UNMutableNotificationContent()
+            content.title = "\(item.name)"
+            content.body = "It's been another week since \(item.name)!"
+            content.sound = UNNotificationSound.default
 
-                let dateComponents = getDateComponentsFor(item: item, extraDays: Double(i) * 7)
-                let trigger = UNCalendarNotificationTrigger(
-                    dateMatching: dateComponents,
-                    repeats: false
-                )
+//                let dateComponents = getDateComponentsFor(item: item, extraDays: Double(i) * 7)
+            var dateComponents = DateComponents()
+            dateComponents.calendar = Calendar.current
+            let weekday = Calendar.current.component(.weekday, from: item.dateLastDone)
+            dateComponents.weekday = weekday
+            dateComponents.hour = 10
+            dateComponents.minute = 0
+            
+            let trigger = UNCalendarNotificationTrigger(
+                dateMatching: dateComponents,
+                repeats: true
+            )
 
-                let request = UNNotificationRequest(
-                    identifier: "\(item.reminderNotificationID)\(i)",
-                    content: content,
-                    trigger: trigger
-                )
-                requests.append(request)
-            }
+            let request = UNNotificationRequest(
+                identifier: "\(item.reminderNotificationID)",
+                content: content,
+                trigger: trigger
+            )
+            requests.append(request)
+            
         case .monthly:
-            for i in 0 ... 3 {
-                let content = UNMutableNotificationContent()
-                content.title = "\(item.name)"
-                content.body = "It's been \(item.daysAgo + (i * 30)) days since \(item.name)!"
-                content.sound = UNNotificationSound.default
+            let content = UNMutableNotificationContent()
+            content.title = "\(item.name)"
+            content.body = "It's been another month since \(item.name)!"
+            content.sound = UNNotificationSound.default
 
-                let dateComponents = getDateComponentsFor(item: item, extraDays: Double(i) * 30)
-                let trigger = UNCalendarNotificationTrigger(
-                    dateMatching: dateComponents,
-                    repeats: false
-                )
+//                let dateComponents = getDateComponentsFor(item: item, extraDays: Double(i) * 30)
+            var dateComponents = DateComponents()
+            dateComponents.calendar = Calendar.current
+            let weekday = Calendar.current.component(.weekday, from: item.dateLastDone)
+            dateComponents.weekday = weekday
+            let weekOfMonth = Calendar.current.component(.weekOfMonth, from: item.dateLastDone)
+            dateComponents.weekOfMonth = weekOfMonth
+            dateComponents.hour = 10
+            dateComponents.minute = 0
+            
+            let trigger = UNCalendarNotificationTrigger(
+                dateMatching: dateComponents,
+                repeats: true
+            )
 
-                let request = UNNotificationRequest(
-                    identifier: "\(item.reminderNotificationID)\(i)",
-                    content: content,
-                    trigger: trigger
-                )
-                requests.append(request)
-            }
+            let request = UNNotificationRequest(
+                identifier: "\(item.reminderNotificationID)",
+                content: content,
+                trigger: trigger
+            )
+            requests.append(request)
+        
         default:
             return
         }
@@ -179,7 +198,11 @@ class NotificationManager: ObservableObject {
         center.getNotificationSettings { settings in
             if settings.authorizationStatus == .authorized {
                 for request in requests {
+                    
+                    self.center.removePendingNotificationRequests(withIdentifiers: ["\(item.reminderNotificationID)"])
                     self.center.add(request)
+                    
+                    print("🗑️ Removed pending notification requests with indetifiers \([item.reminderNotificationID])")
                     print("🔔 Added notification!")
                     print("The request is: \(request)")
                 }

--- a/DaysSince/NotificationManager.swift
+++ b/DaysSince/NotificationManager.swift
@@ -91,9 +91,12 @@ class NotificationManager: ObservableObject {
     /// Add reminders for a days since event
     /// - Parameter item: Days Since event to schedule reminders for
     func addReminderFor(item: DSItem) {
-//        var notificationsContent: [UNMutableNotificationContent]
 
         var requests: [UNNotificationRequest] = []
+        
+        // Time for the notifications is hardcoded at 10am
+        let hour = 10
+        let minute = 0
 
         switch item.reminder {
             
@@ -103,11 +106,10 @@ class NotificationManager: ObservableObject {
             content.body = "One more day since \(item.name)!"
             content.sound = UNNotificationSound.default
 
-//                let dateComponents = getDateComponentsFor(item: item, extraDays: Double(i))
             let calendar = Calendar.current
             var dateComponents = DateComponents(calendar: calendar, timeZone: TimeZone.current)
-            dateComponents.hour = 10
-            dateComponents.minute = 0
+            dateComponents.hour = hour
+            dateComponents.minute = minute
             
             let trigger = UNCalendarNotificationTrigger(
                 dateMatching: dateComponents,
@@ -127,13 +129,12 @@ class NotificationManager: ObservableObject {
             content.body = "It's been another week since \(item.name)!"
             content.sound = UNNotificationSound.default
 
-//                let dateComponents = getDateComponentsFor(item: item, extraDays: Double(i) * 7)
             var dateComponents = DateComponents()
             dateComponents.calendar = Calendar.current
             let weekday = Calendar.current.component(.weekday, from: item.dateLastDone)
             dateComponents.weekday = weekday
-            dateComponents.hour = 10
-            dateComponents.minute = 0
+            dateComponents.hour = hour
+            dateComponents.minute = minute
             
             let trigger = UNCalendarNotificationTrigger(
                 dateMatching: dateComponents,
@@ -153,15 +154,12 @@ class NotificationManager: ObservableObject {
             content.body = "It's been another month since \(item.name)!"
             content.sound = UNNotificationSound.default
 
-//                let dateComponents = getDateComponentsFor(item: item, extraDays: Double(i) * 30)
             var dateComponents = DateComponents()
             dateComponents.calendar = Calendar.current
-            let weekday = Calendar.current.component(.weekday, from: item.dateLastDone)
-            dateComponents.weekday = weekday
-            let weekOfMonth = Calendar.current.component(.weekOfMonth, from: item.dateLastDone)
-            dateComponents.weekOfMonth = weekOfMonth
-            dateComponents.hour = 10
-            dateComponents.minute = 0
+            let dayOfMonth = Calendar.current.component(.day, from: item.dateLastDone)
+            dateComponents.day = dayOfMonth
+            dateComponents.hour = hour
+            dateComponents.minute = minute
             
             let trigger = UNCalendarNotificationTrigger(
                 dateMatching: dateComponents,


### PR DESCRIPTION
## Overall 
There was a bug with the notifications spamming. Basically we used to schedule several monthly, weekly, and daily notifications. The monthly and weekly all deliver at the same time like this. 
![Simulator Screenshot - iPhone 15 Pro - 2025-04-03 at 10 45 26](https://github.com/user-attachments/assets/742a682c-30ea-4bde-9bde-c59ec4fb4b5d)

## Reason
It wasn't like this before. Could be a new bug after the iOS updates, I don't know. 

## Fix
To fix it I removed the for loop where we schedule multiple notifications for the same event. Now we schedule one notification per event and the notification is repeating. 

## New notifications
- Daily notifications - delivered daily at 10am in the user's timezone
- Weekly notifications - if an event happened on day X (i.e., Monday) of the week, then all weekly notifications are delivered on the X day (i.e., every Monday) of each week. 
- Monthly notifications - if an event happened on day Y (i.e., the 3rd) of a month, then all monthly notifications are delivered on the Y (i.e., 3rd) of each month. There are some edge cases - what if an event occurred on March 31st - the calendar is supposed to handle this. It should just deliver them on the last day of each month that is shorter than 31 days (i.e., on the 30th of April). 
